### PR TITLE
2503 Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ## 2503.1
 
-- Added parameter **WindowsVersion** (`breaking change`)
+- Added new parameter **WindowsVersion** that supports value **10**, **11**, **2022** and **2025** (`breaking change`)
 - Removed parameter **Windows10Version** (`breaking change`)
 - Removed parameter **Windows11Version** (`breaking change`)
 - Renamed product **Microsoft Office** to **Microsoft 365 Apps** (`breaking change`)
@@ -27,14 +27,16 @@
 - Improved verbose logging
 - Fixed issues with PreferLocalOneDrive parameter
 - Added admx for Windows Server 2025
+- Added admx for Windows Server 2022
 - Added admx for Zoom VDI
 - Renamed functions to get url and latest version of policy definitions files from Get-$ProductAdmxOnline to Get-EvergreenAdmx%Product%
 - Renamed functions to download policy definitions files from Get-$ProductAdmx to Invoke-EvergreenAdmx%Product%
 - Added new Update-AdmxVersion function
 - Added admx for Brave Browser [#48](https://github.com/msfreaks/EvergreenAdmx/issues/48) Thanks [Tom Plant](https://github.com/pl4nty)!
-- Fix scrapping for OneDrive [#55](https://github.com/msfreaks/EvergreenAdmx/pull/55) Thanks [Tom Plant](https://github.com/pl4nty)!
-- Fix Windows 11, OneDrive and Office policies downloads [#51](https://github.com/msfreaks/EvergreenAdmx/issues/51) Thanks [Tom Plant](https://github.com/pl4nty)!
-- Improved code formatting
+- Fixed scrapping for OneDrive [#55](https://github.com/msfreaks/EvergreenAdmx/pull/55) Thanks [Tom Plant](https://github.com/pl4nty)!
+- Fix Windows 11, OneDrive and 365 apps admx downloads [#51](https://github.com/msfreaks/EvergreenAdmx/issues/51) Thanks [Tom Plant](https://github.com/pl4nty)!
+- Fixed errors reported by PSScriptAnalyzer rules
+- Improved code formatting based on powershell and markdown best practices
 
 ## 2411.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,175 +2,199 @@
 
 ## To do
 
-*  Fix PreferLocalOneDrive parameter
-*  Replace Invoke-WebRequest by Invoke-Download to improve download speed
-*  Add logging options (yep, since the beginning)
-*  Add notification options (yep, also since the beginning)
-*  Detect user domain automatically (Get code from PSADT)
-*  Add support for Winget-Autoupdate-Intune ADMX [#35](https://github.com/msfreaks/EvergreenAdmx/issues/35)
-*  Add parameter to create Central Policy Store location
-*  Add parameter to clean old Office ADMX from Central Policy Store location
-*  Add parameter to clean old Adobe Reader ADMX from Central Policy Store location
+- Add logging options (yep, since the beginning)
+- Add notification options (yep, also since the beginning)
+- Detect user domain automatically (Get code from PSADT)
+- Add support for Winget-Autoupdate-Intune ADMX
+- Add parameter to create Central Policy Store location
+- Add parameter to clean old Office ADMX from Central Policy Store location
+- Add parameter to clean old Adobe Reader ADMX from Central Policy Store location
+- Add SSL admx
+- Add Dell Command Update admx
+- Add Winget-Auto-Update admx
+- Add Winget-Auto-Update-Intune admx
+- Add Slack admx [#57](https://github.com/msfreaks/EvergreenAdmx/issues/57)
+
+## 2503.1
+
+- Added parameter **WindowsVersion** (`breaking change`)
+- Removed parameter **Windows10Version** (`breaking change`)
+- Removed parameter **Windows11Version** (`breaking change`)
+- Renamed product **Microsoft Office** to **Microsoft 365 Apps** (`breaking change`)
+- Renamed product **Azure Virtual Desktop** to **Microsoft AVD** (`breaking change`)
+- Renamed product **FSLogix** to **Microsoft FSlogix** (`breaking change`)
+- Renamed product **Zoom Desktop Client** to **Zoom** (`breaking change`)
+- Improved verbose logging
+- Fixed issues with PreferLocalOneDrive parameter
+- Added admx for Windows Server 2025
+- Added admx for Zoom VDI
+- Renamed functions to get url and latest version of policy definitions files from Get-$ProductAdmxOnline to Get-EvergreenAdmx%Product%
+- Renamed functions to download policy definitions files from Get-$ProductAdmx to Invoke-EvergreenAdmx%Product%
+- Added new Update-AdmxVersion function
+- Added admx for Brave Browser [#48](https://github.com/msfreaks/EvergreenAdmx/issues/48) Thanks [Tom Plant](https://github.com/pl4nty)!
+- Fix scrapping for OneDrive [#55](https://github.com/msfreaks/EvergreenAdmx/pull/55) Thanks [Tom Plant](https://github.com/pl4nty)!
+- Fix Windows 11, OneDrive and Office policies downloads [#51](https://github.com/msfreaks/EvergreenAdmx/issues/51) Thanks [Tom Plant](https://github.com/pl4nty)!
+- Improved code formatting
 
 ## 2411.1
 
-* Added admx for Microsoft Winget [#40](https://github.com/msfreaks/EvergreenAdmx/issues/40)
+- Added admx for Microsoft Winget [#40](https://github.com/msfreaks/EvergreenAdmx/issues/40)
 
 ## 2411.0
 
-* Changed Get-WindowsAdmxOnline version return
-* Added Admx for Microsoft Windows 11 (24H2) [#45](https://github.com/msfreaks/EvergreenAdmx/issues/45)
+- Changed Get-WindowsAdmxOnline version return
+- Added Admx for Microsoft Windows 11 (24H2) [#45](https://github.com/msfreaks/EvergreenAdmx/issues/45)
 
 ## 2402.1
 
-* Fixed Get-WindowsAdmxOnline version return
-* Improved function Get-WindowsAdmxOnline, added default parameters
-* Improved function Get-WindowsAdmxDownloadId, added default parameters
-* Improved Get-WindowsAdmx speed by switching to MSI extraction [#41](https://github.com/msfreaks/EvergreenAdmx/issues/41)
-* Improved Adobe admx downloads with https URLs [#37](https://github.com/msfreaks/EvergreenAdmx/issues/37)
-* Added admx for Microsoft Windows 11 (23H2) [#38](https://github.com/msfreaks/EvergreenAdmx/issues/38)
-* Added back WindowsVersion parameter as an alias for Windows11Version
-* Added admx for Azure Virtual Desktop [#17](https://github.com/msfreaks/EvergreenAdmx/issues/17)
-* Added new functions [Get-Link](https://github.com/DanGough/Nevergreen/blob/main/Nevergreen/Private/Get-Link.ps1), [Get-Version](https://github.com/DanGough/Nevergreen/blob/main/Nevergreen/Private/Get-Version.ps1) and [Resolve-Uri](https://github.com/DanGough/Nevergreen/blob/main/Nevergreen/Private/Resolve-Uri.ps1). Thanks [Dan Gough](https://github.com/DanGough)!
-* Added new function [Invoke-Download](https://github.com/DanGough/PsDownload/blob/main/PsDownload/Public/Invoke-Download.ps1) to improve download speed and get last modified date. Thanks [Dan Gough](https://github.com/DanGough)!
-* Replaced Get-RedirectUrl function by Resolve-Uri Thanks [Dan Gough](https://github.com/DanGough)!
-* Fixed and improved Zoom Desktop Client version and url detection. Now works on PowerShell 5.1 as well! Thanks [Dan Gough](https://github.com/DanGough)!
-* Fixed Zoom Desktop Client admx copy to policy definitions
-* Fixed and improved Get-MicrosoftOfficeAdmxOnline version detection
-* Fixed and improved Get-MDOPAdmxOnline version detection
-* Improved Get-FSLogixOnline
-* Fixed and improved Get-OneDriveOnline, now use [EvergreenApi](https://stealthpuppy.com/evergreen/invoke) method for version and url detection
-* Microsoft OneDrive now install silently
-* Fixed typo
-* Updated help
+- Fixed Get-WindowsAdmxOnline version return
+- Improved function Get-WindowsAdmxOnline, added default parameters
+- Improved function Get-WindowsAdmxDownloadId, added default parameters
+- Improved Get-WindowsAdmx speed by switching to MSI extraction [#41](https://github.com/msfreaks/EvergreenAdmx/issues/41)
+- Improved Adobe admx downloads with https URLs [#37](https://github.com/msfreaks/EvergreenAdmx/issues/37)
+- Added admx for Microsoft Windows 11 (23H2) [#38](https://github.com/msfreaks/EvergreenAdmx/issues/38)
+- Added back WindowsVersion parameter as an alias for Windows11Version
+- Added admx for Azure Virtual Desktop [#17](https://github.com/msfreaks/EvergreenAdmx/issues/17)
+- Added new functions [Get-Link](https://github.com/DanGough/Nevergreen/blob/main/Nevergreen/Private/Get-Link.ps1), [Get-Version](https://github.com/DanGough/Nevergreen/blob/main/Nevergreen/Private/Get-Version.ps1) and [Resolve-Uri](https://github.com/DanGough/Nevergreen/blob/main/Nevergreen/Private/Resolve-Uri.ps1). Thanks [Dan Gough](https://github.com/DanGough)!
+- Added new function [Invoke-Download](https://github.com/DanGough/PsDownload/blob/main/PsDownload/Public/Invoke-Download.ps1) to improve download speed and get last modified date. Thanks [Dan Gough](https://github.com/DanGough)!
+- Replaced Get-RedirectUrl function by Resolve-Uri Thanks [Dan Gough](https://github.com/DanGough)!
+- Fixed and improved Zoom Desktop Client version and url detection. Now works on PowerShell 5.1 as well! Thanks [Dan Gough](https://github.com/DanGough)!
+- Fixed Zoom Desktop Client admx copy to policy definitions
+- Fixed and improved Get-MicrosoftOfficeAdmxOnline version detection
+- Fixed and improved Get-MDOPAdmxOnline version detection
+- Improved Get-FSLogixOnline
+- Fixed and improved Get-OneDriveOnline, now use [EvergreenApi](https://stealthpuppy.com/evergreen/invoke) method for version and url detection
+- Microsoft OneDrive now install silently
+- Fixed typo
+- Updated help
 
 ## 2301.2
 
-* Fixed typo in New-Item command (thanks for pointing it out, riebest!)
+- Fixed typo in New-Item command (thanks for pointing it out, riebest!)
 
 ## 2301.1
 
-* Added Admx for Microsoft Windows 10 (22H2)
-* Added Admx for Adobe Reader and Adobe Acrobat (`breaking change`)
-* Fixed Microsoft Edge (Chromium) Admx download
-* Fixed Zoom Desktop Client Admx downloads (hardcoded version)
-* Replaced mkdir command by native posh one
-* Cleanup code
+- Added Admx for Microsoft Windows 10 (22H2)
+- Added Admx for Adobe Reader and Adobe Acrobat
+- Fixed Microsoft Edge (Chromium) Admx download
+- Fixed Zoom Desktop Client Admx downloads (hardcoded version)
+- Replaced mkdir command by native posh one
+- Cleanup code
 
 ## 2209.1
 
-* Fixed bug for Microsoft OneDrive, thanks Jonathan!
-* Fixed bug for Citrix Workspace App
-* Added Admx for Microsoft Windows 11 (22H2)
-* Added cleanup logic for Google Chrome ADMX version checking, thanks for noticing Jonathan!
-* Cleanup on code, thanks Jonathan!
+- Fixed bug for Microsoft OneDrive, thanks Jonathan!
+- Fixed bug for Citrix Workspace App
+- Added admx for Microsoft Windows 11 (22H2)
+- Added cleanup logic for Google Chrome ADMX version checking, thanks for noticing Jonathan!
+- Cleanup on code, thanks Jonathan!
 
 ## 2207.1
 
-* Fixed bug where Citrix Workspace App would fail, thanks to Jonathan Pitre! (https://github.com/JonathanPitre)
+- Fixed bug where Citrix Workspace App would fail, thanks to [Jonathan Pitre](https://github.com/JonathanPitre)!
 
 ## 2206.1
 
-* Added requirement for elevation to prevent running unelevated
-* Added parameter -UseDefaultCredentials to all Invoke-WebRequest commands, except for Adobe since that is ftp :(
-* Fixed bug where Amd64 OneDrive would mess everything up
-* Removed support for Zoom Desktop Client (403 error when checking for new version)
+- Added requirement for elevation to prevent running unelevated
+- Added parameter -UseDefaultCredentials to all Invoke-WebRequest commands, except for Adobe since that is ftp :(
+- Fixed bug where Amd64 OneDrive would mess everything up
+- Removed support for Zoom Desktop Client (403 error when checking for new version)
 
 ## 2112.2
 
-* Fixed bug where Windows 10 would throw a WindowsVersion variable error
+- Fixed bug where Windows 10 would throw a WindowsVersion variable error
 
 ## 2112.1
 
 `Breaking change introduced!` (See [README][read-me] for more info)
 
-* Added parameter 'Windows10Version' (`breaking change`)
-* Added parameter 'Windows11Version' (`breaking change`)
-* Removed parameter 'WindowsVersion' (`breaking change`)
-* Added Admx for Microsoft Windows 10 (21H2)
-* Added Admx for Microsoft Windows 11 (21H2)
-* Fixed bug where copying the ADMX files for Citrix Workspace App would fail
-* Fixed bug where terminating a running OneDrive process would fail if a process was not found
+- Added parameter 'Windows10Version' (`breaking change`)
+- Added parameter 'Windows11Version' (`breaking change`)
+- Removed parameter 'WindowsVersion' (`breaking change`)
+- Added Admx for Microsoft Windows 10 (21H2)
+- Added Admx for Microsoft Windows 11 (21H2)
+- Fixed bug where copying the ADMX files for Citrix Workspace App would fail
+- Fixed bug where terminating a running OneDrive process would fail if a process was not found
 
 ## 2111.1
 
-*  Internal version
+- Internal version
 
 ## 2109.2
 
-* Fixed bug where uninstall information for OneDrive would throw an error
+- Fixed bug where uninstall information for OneDrive would throw an error
 
 ## 2109.1
 
-* Fixed bug where downloading the ADMX files for Citrix Workspace App would fail
-* Fixed bug where downloading the ADMX files for BIS-F would fail to copy the .adml file
-* Fixed bug where downloading the ADMX files for Microsoft OneDrive would fail
+- Fixed bug where downloading the ADMX files for Citrix Workspace App would fail
+- Fixed bug where downloading the ADMX files for BIS-F would fail to copy the .adml file
+- Fixed bug where downloading the ADMX files for Microsoft OneDrive would fail
 
 ## 2107.1
 
-* Fixed bug where Get-FSLogixOnline would fail using code provided by severud (thanks!)
-* Typo corrected for Windows 20 (21H1)
+- Fixed bug where Get-FSLogixOnline would fail using code provided by severud (thanks!)
+- Typo corrected for Windows 20 (21H1)
 
 ## 2106.2
 
-*  Fixed bug where script was unable to get the version for Citrix Workspace App Admx
+- Fixed bug where script was unable to get the version for Citrix Workspace App Admx
 
 ## 2106.1
 
-*  Added Admx for Microsoft Windows 10 (21H1)
+- Added Admx for Microsoft Windows 10 (21H1)
 
 ## 2101.2
 
 `Breaking change introduced!` (See [README][read-me] for more info)
 
-*  Added parameter 'CustomPolicyLocation'
-*  Added 'CustomPolicyLocation' logic
-*  Added parameter 'Include' (`breaking change`)
-*  Added 'Include' logic
-*  Added parameter 'PreferLocalOneDrive'
-*  Added 'PreferLocalOneDrive' logic
+- Added parameter 'CustomPolicyLocation'
+- Added 'CustomPolicyLocation' logic
+- Added parameter 'Include' (`breaking change`)
+- Added 'Include' logic
+- Added parameter 'PreferLocalOneDrive'
+- Added 'PreferLocalOneDrive' logic
 
 ## 2101.1
 
-*  Internal version
+- Internal version
 
 ## 2012.6
 
-*  Added parameter 'UseProductFolders'
-*  Added parameter 'Languages'
-*  Added 'UseProductFolders' logic
-*  Added 'Languages' logic
-*  Fixed bug where extracting of .cab files would fail
-*  Updated verbose output
+- Added parameter 'UseProductFolders'
+- Added parameter 'Languages'
+- Added 'UseProductFolders' logic
+- Added 'Languages' logic
+- Fixed bug where extracting of .cab files would fail
+- Updated verbose output
 
 ## 2012.5
 
-*  Added Admx for Base Image Script Framework (BIS-F)
-*  Added Admx for Microsoft Desktop Optimization Pack (disabled by default)
-*  Updated cleanup logic
+- Added Admx for Base Image Script Framework (BIS-F)
+- Added Admx for Microsoft Desktop Optimization Pack (disabled by default)
+- Updated cleanup logic
 
 ## 2012.4
 
-*  Added Admx for Adobe AcrobatReader DC
-*  Added Admx for Citrix Workspace App
-*  Added Admx for Mozilla Firefox
-*  Added Admx for Zoom Desktop Client
+- Added Admx for Adobe AcrobatReader DC
+- Added Admx for Citrix Workspace App
+- Added Admx for Mozilla Firefox
+- Added Admx for Zoom Desktop Client
 
 ## 2012.3
 
-*  Added Admx for Google Chrome
-*  Fixed bug where hash for json output would throw an error. Switched to Xml output.
+- Added Admx for Google Chrome
+- Fixed bug where hash for json output would throw an error. Switched to Xml output.
 
 ## 2012.2
 
-*  Added .xml file for Scheduled Task creation
+- Added .xml file for Scheduled Task creation
 
 ## 2012.1
 
-*  Added Admx for Microsoft Windows 10 (1903/1909/2004/20H2)
-*  Added Admx for Microsoft Edge (Chromium)
-*  Added Admx for Microsoft OneDrive
-*  Added Admx for Microsoft Office
-*  Added Admx for FSLogix
+- Added Admx for Microsoft Windows 10 (1903/1909/2004/20H2)
+- Added Admx for Microsoft Edge (Chromium)
+- Added Admx for Microsoft OneDrive
+- Added Admx for Microsoft Office
+- Added Admx for FSLogix
 
 [read-me]: https://github.com/msfreaks/EvergreenAdmx/blob/main/README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@
 
 ## 2503.1
 
-- Added new parameter **WindowsVersion** that supports value **10**, **11**, **2022** and **2025** (`breaking change`)
-- Removed parameter **Windows10Version** (`breaking change`)
-- Removed parameter **Windows11Version** (`breaking change`)
+- Added script parameter **WindowsVersion** that supports value **10**, **11**, **2022** and **2025** (`breaking change`)
+- Replaced script parameter **Windows10Version** and **Windows11Version** by **WindowsFeatureVersion** (`breaking change`)
 - Renamed product **Microsoft Office** to **Microsoft 365 Apps** (`breaking change`)
 - Renamed product **Azure Virtual Desktop** to **Microsoft AVD** (`breaking change`)
 - Renamed product **FSLogix** to **Microsoft FSlogix** (`breaking change`)
 - Renamed product **Zoom Desktop Client** to **Zoom** (`breaking change`)
+- Improved script parameters validation
 - Improved verbose logging
 - Fixed issues with PreferLocalOneDrive parameter
 - Added admx for Windows Server 2025

--- a/Dell Command Update/Dell Command Update.admx
+++ b/Dell Command Update/Dell Command Update.admx
@@ -1,0 +1,938 @@
+<?xml version="1.0"?>
+<!--
+/* DELL PROPRIETARY INFORMATION
+*
+* This software contains the intellectual property of Dell Inc. Use of this software and the intellectual property
+* contained therein is expressly limited to the terms and conditions of the License Agreement under which it is
+* provided by or on behalf of Dell Inc. or its subsidiaries.
+*
+* Copyright 2023-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+* 
+*  DELL INC. MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF THE SOFTWARE, EITHER
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.  DELL SHALL NOT BE LIABLE FOR ANY DAMAGES * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+* DERIVATIVES.
+*/
+-->
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions" >
+
+	<policyNamespaces>
+	<target prefix="CommandUpdate" namespace="Dell.Policies.CommandUpdate" />
+    <using namespace="Dell.Policies" prefix="Dell"/>
+	</policyNamespaces>
+        <supersededAdm fileName="Dell Command Update.adm" />
+	<resources minRequiredRevision="1.0" fallbackCulture="en-US"/>
+	<supportedOn >
+		<definitions >
+			<definition name="SupportedOn_1" displayName="$(string.String_SupportedOn_Windows_10_Windows_2)" />
+			<definition name="SupportedOn_178" displayName="$(string.String_SupportedOn_Undefined_179)" />
+		</definitions>
+	</supportedOn>
+	<categories ><!--Storage for Category Definitions-->
+
+		<category displayName="$(string.String_Dell_Command_Update)" name="DellCommandUpdate">
+		  <parentCategory ref="Dell:Cat_Dell"/>
+		</category>		
+		<category name="Cat_Device_Category_5" displayName="$(string.String_Cat_Device_Category_6)" >
+			<parentCategory ref="DellCommandUpdate" />
+		</category>
+		<category name="Cat_Recommended_Levels_7" displayName="$(string.String_Cat_Recommended_Levels_8)" >
+			<parentCategory ref="DellCommandUpdate" />
+		</category>
+		<category name="Cat_Update_Settings_9" displayName="$(string.String_Cat_Update_Settings_10)" >
+			<parentCategory ref="DellCommandUpdate" />
+		</category>
+		<category name="Cat_Update_Types_11" displayName="$(string.String_Cat_Update_Types_12)" >
+			<parentCategory ref="DellCommandUpdate" />
+		</category>
+	</categories>
+	<policies ><!--Storage for Policy Definitions-->
+		
+		<policy name="Policy_Enable_Lock_Settings_16" class="Machine" displayName="$(string.String_Policy_Enable_Lock_Settings_17)" explainText="$(string.String_Explain_When_this_setting_18)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\CFG" valueName="LockSettings" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Enable_User_Consent_22" class="Machine" displayName="$(string.String_Policy_Enable_User_Consent_23)" explainText="$(string.String_Explain_When_this_setting_24)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" valueName="UserConsent" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		
+		<policy name="Policy_Allow_Catalog_xml" class="Machine" displayName="$(string.String_Policy_Allow_Catalog_xml)" explainText="$(string.String_Policy_Allow_Catalog_xml_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" valueName="EnableCatalogXML" >
+                        <parentCategory ref="DellCommandUpdate" />
+                        <supportedOn ref="SupportedOn_1" />
+                        <enabledValue >
+                                <decimal value="1" />
+                        </enabledValue>
+						<disabledValue >
+							<decimal value="0" />
+						</disabledValue>
+
+        </policy>
+
+		<policy name="Policy_Enable_the_Default_180" class="Machine" displayName="$(string.String_Policy_Enable_the_Default_181)" explainText="$(string.String_Explain_When_this_setting_182)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" valueName="EnableDefaultDellCatalog" >
+					<value >
+						<decimal value="1" />
+					</value>
+				</item>
+			</enabledList>
+			<disabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" valueName="EnableDefaultDellCatalog" >
+					<value >
+						<decimal value="0" />
+					</value>
+				</item>
+			</disabledList>
+		</policy>
+		<policy name="Policy_Enable_Autosuspend_25" class="Machine" displayName="$(string.String_Policy_Enable_Autosuspend_26)" explainText="$(string.String_Explain_When_this_setting_27)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" valueName="SuspendBitLocker" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Set_the_Download_28" class="Machine" displayName="$(string.String_Policy_Set_the_Download_29)" explainText="$(string.String_Explain_Change_where_the_30)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" presentation="$(presentation.Policy_Set_the_Download_28)" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+			<elements >
+				<text id="Policy_TextBox_Element_Set_the_Download_31" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" valueName="DownloadPath" maxLength="255" />
+			</elements>
+		</policy>
+
+		<policy name="Policy_Proxy_fallback" class="Machine" displayName="$(string.String_Policy_Proxy_fallback)" explainText="$(string.String_Policy_Proxy_fallback_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" valueName="EnableProxyFallbackToDirectConnection" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+
+		<policy name="Policy_Configure_proxy" class="Machine" displayName="$(string.String_Policy_Configure_Proxy)" explainText="$(string.String_Policy_Configure_Proxy_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" presentation="$(presentation.Policy_Configure_proxy_placeholder)" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+
+			<enabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" valueName="UseDefaultProxy" >
+					<value >
+						<decimal value="0" />
+					</value>
+				</item>
+			</enabledList>
+			<disabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" valueName="UseDefaultProxy" >
+					<value >
+						<decimal value="1" />
+					</value>
+				</item>
+			</disabledList>
+			<elements >
+				<text id="Policy_TextBox_Element_Configure_proxy_server" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" valueName="Server" maxLength="255" required="true" />
+			</elements>
+		</policy>
+		
+		<policy name="Policy_Configure_proxy_port" class="Machine" displayName="$(string.String_Policy_Configure_Proxy_port)" explainText="$(string.String_Policy_Configure_Proxy_port_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" presentation="$(presentation.Policy_Configure_proxy_port_placeholder)" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+
+			<elements >
+				<decimal id="Policy_TextBox_Element_Configure_proxy_port" valueName="Port" minValue="0" maxValue="65535" required="true" />
+			</elements>
+		</policy>
+
+
+		<policy name="Configure_proxy_authentication" class="Machine" displayName="$(string.String_Policy_Configure_Proxy_auth)" explainText="$(string.String_Policy_Configure_Proxy_auth_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings\ProxyAuthentication" presentation="$(presentation.Configure_proxy_authentication_placeholder)" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+
+			<enabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" valueName="UseAuthentication" >
+					<value >
+						<decimal value="1" />
+					</value>
+				</item>
+			</enabledList>
+			<disabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings" valueName="UseAuthentication" >
+					<value >
+						<decimal value="0" />
+					</value>
+				</item>
+			</disabledList>
+			<elements >
+				<text id="Policy_TextBox_Element_Configure_proxy_auth_username" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General\CustomProxySettings\ProxyAuthentication" valueName="UserName" maxLength="255" required="true" />
+			</elements>
+		</policy>
+
+		<policy name="Policy_Disable_ADR" class="Machine" displayName="$(string.String_Policy_Disable_ADR)" explainText="$(string.String_Policy_Disable_ADR_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\AdvancedDriverRestore" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+
+			<enabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\AdvancedDriverRestore" valueName="IsAdvancedDriverRestoreEnabled" >
+					<value >
+						<decimal value="0" />
+					</value>
+				</item>
+			</enabledList>
+			<disabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\AdvancedDriverRestore" valueName="IsAdvancedDriverRestoreEnabled" >
+					<value >
+						<decimal value="1" />
+					</value>
+				</item>
+			</disabledList>
+
+		</policy>
+
+		<policy name="Policy_Configure_driver_library" class="Machine" displayName="$(string.String_Policy_Configure_Driver_Library)" explainText="$(string.String_Policy_Configure_Driver_Library_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\AdvancedDriverRestore" presentation="$(presentation.Policy_Configure_Driver_library)" >
+			<parentCategory ref="DellCommandUpdate" />
+			<supportedOn ref="SupportedOn_1" />
+
+			<enabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\AdvancedDriverRestore" valueName="IsCabSourceDell" >
+					<value >
+						<decimal value="0" />
+					</value>
+				</item>
+			</enabledList>
+			<disabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\AdvancedDriverRestore" valueName="IsCabSourceDell" >
+					<value >
+						<decimal value="1" />
+					</value>
+				</item>
+			</disabledList>
+			<elements >
+				<text id="Policy_TextBox_Element_Configure_driver_library_path" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\AdvancedDriverRestore" valueName="CabPath" required="true" />
+			</elements>
+		</policy>
+
+		<policy name="Policy_Disable_Notifications" class="Machine" displayName="$(string.String_Policy_Disable_Notifications)" explainText="$(string.String_Policy_Disable_Notifications_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" valueName="DisableNotification" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+
+		<policy name="Policy_Mandatory_Reboot" class="Machine" displayName="$(string.String_Policy_Mandatory_Reboot)" explainText="$(string.String_Policy_Mandatory_Reboot_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" valueName="EnableForceRestart" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+
+		<policy name="Policy_Maximum_Retry_Attempts" class="Machine" displayName="$(string.String_Policy_Maximum_Retry_Attempts)" explainText="$(string.String_Policy_Maximum_Retry_Attempts_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" presentation="$(presentation.Policy_Maximum_Retry_Attempts_dropdown)" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<elements >
+				<enum id="Policy_DropList_Element_Maximum_Retry_Attempts" valueName="MaxRetryAttempts" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" required="true" >
+					<item displayName="$(string.String_Policy_DropList_Select_Maximum_Retry_Attempts_1)" >
+						<value >
+							<decimal value="1" />
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Maximum_Retry_Attempts_2)" >
+						<value >
+							<decimal value="2" />
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Maximum_Retry_Attempts_3)" >
+						<value >
+							<decimal value="3" />
+						</value>
+					</item>
+				</enum>
+			</elements>
+		</policy>
+
+		<policy name="Policy_Chipset_Drivers_36" class="Machine" displayName="$(string.String_Policy_Chipset_Drivers_37)" explainText="$(string.String_Explain_When_this_setting_38)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\DeviceCategory" valueName="IsChipsetSelected" >
+			<parentCategory ref="Cat_Device_Category_5" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Storage_e_g_Hard_39" class="Machine" displayName="$(string.String_Policy_Storage_e_g_Hard_40)" explainText="$(string.String_Explain_When_this_setting_41)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\DeviceCategory" valueName="IsStorageSelected" >
+			<parentCategory ref="Cat_Device_Category_5" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Video_Drivers_42" class="Machine" displayName="$(string.String_Policy_Video_Drivers_43)" explainText="$(string.String_Explain_When_this_setting_44)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\DeviceCategory" valueName="IsVideoSelected" >
+			<parentCategory ref="Cat_Device_Category_5" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Input_e_g_Mouse_45" class="Machine" displayName="$(string.String_Policy_Input_e_g_Mouse_46)" explainText="$(string.String_Explain_When_this_setting_47)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\DeviceCategory" valueName="IsInputSelected" >
+			<parentCategory ref="Cat_Device_Category_5" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Audio_Drivers_48" class="Machine" displayName="$(string.String_Policy_Audio_Drivers_49)" explainText="$(string.String_Explain_When_this_setting_50)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\DeviceCategory" valueName="IsAudioSelected" >
+			<parentCategory ref="Cat_Device_Category_5" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Network_Drivers_51" class="Machine" displayName="$(string.String_Policy_Network_Drivers_52)" explainText="$(string.String_Explain_When_this_setting_53)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\DeviceCategory" valueName="IsNetworkSelected" >
+			<parentCategory ref="Cat_Device_Category_5" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_All_Others_54" class="Machine" displayName="$(string.String_Policy_All_Others_55)" explainText="$(string.String_Explain_When_this_setting_56)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\DeviceCategory" valueName="IsDeviceCategoryOtherSelected" >
+			<parentCategory ref="Cat_Device_Category_5" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Security_Updates_57" class="Machine" displayName="$(string.String_Policy_Security_Updates_58)" explainText="$(string.String_Explain_When_this_setting_59)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\RecommendedLevel" valueName="IsSecurityUpdatesSelected" >
+			<parentCategory ref="Cat_Recommended_Levels_7" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Recommended_Updates_60" class="Machine" displayName="$(string.String_Policy_Recommended_Updates_61)" explainText="$(string.String_Explain_When_this_setting_62)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\RecommendedLevel" valueName="IsRecommendedUpdatesSelected" >
+			<parentCategory ref="Cat_Recommended_Levels_7" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Optional_Updates_63" class="Machine" displayName="$(string.String_Policy_Optional_Updates_64)" explainText="$(string.String_Explain_When_this_setting_65)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\RecommendedLevel" valueName="IsOptionalUpdatesSelected" >
+			<parentCategory ref="Cat_Recommended_Levels_7" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Critical_Updates_66" class="Machine" displayName="$(string.String_Policy_Critical_Updates_67)" explainText="$(string.String_Explain_When_this_setting_68)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\RecommendedLevel" valueName="IsCriticalUpdatesSelected" >
+			<parentCategory ref="Cat_Recommended_Levels_7" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Filter_Applicable_Mode" class="Machine" displayName="$(string.String_Policy_Filter_Applicable_Mode)" explainText="$(string.String_Policy_Filter_Applicable_Mode_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter" presentation="$(presentation.Policy_Update_Filter)" >
+                        <parentCategory ref="DellCommandUpdate" />
+                        <supportedOn ref="SupportedOn_1" />
+                        <elements >
+                                <enum id="Policy_DropList_Element_Filter_Applicable_Mode" valueName="FilterApplicableMode" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter" required="true" >
+                                        <item displayName="$(string.String_Policy_DropList_Filter_ShowOnlyForSystemConfig)" >
+                                                <value >
+                                                        <string >ShowOnlyForSystemConfig</string>
+                                                </value>
+                                        </item>
+                                        <item displayName="$(string.String_Policy_DropList_Filter_ShowAllForPlatform)" >
+                                                <value >
+                                                        <string >ShowAllForPlatform</string>
+                                                </value>
+                                        </item>
+                                </enum>
+                        </elements>
+        </policy>
+
+		<policy name="Policy_Update_Settings_69" class="Machine" displayName="$(string.String_Policy_Update_Settings_70)" explainText="$(string.String_Explain_When_this_setting_71)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" presentation="$(presentation.Policy_Update_Settings_69)" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<elements >
+				<enum id="Policy_DropList_Element_Update_Settings_72" valueName="ScheduleMode" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" required="true" >
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Manual_Updates_73)" >
+						<value >
+							<string >ManualUpdates</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Automatic_Updates_74)" >
+						<value >
+							<string >Auto</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Daily)" >
+						<value >
+							<string >Daily</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Weekly_75)" >
+						<value >
+							<string >Weekly</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Monthly_76)" >
+						<value >
+							<string >Monthly</string>
+						</value>
+					</item>
+				</enum>
+				<enum id="Policy_DropList_Element_Update_Settings_77" valueName="DayOfWeek" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" required="true" >
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Sunday_78)" >
+						<value >
+							<string >Sunday</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Monday_79)" >
+						<value >
+							<string >Monday</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Tuesday_80)" >
+						<value >
+							<string >Tuesday</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Wednesday_81)" >
+						<value >
+							<string >Wednesday</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Thursday_82)" >
+						<value >
+							<string >Thursday</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Friday_83)" >
+						<value >
+							<string >Friday</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_Saturday_84)" >
+						<value >
+							<string >Saturday</string>
+						</value>
+					</item>
+				</enum>
+				<enum id="Policy_DropList_Element_Update_Settings_85" valueName="Time" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" required="true" >
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_12_00_AM_DEFAULT_86)" >
+						<value >
+							<string >00:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_1_00_AM_87)" >
+						<value >
+							<string >01:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_2_00_AM_88)" >
+						<value >
+							<string >02:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_3_00_AM_89)" >
+						<value >
+							<string >03:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_4_00_AM_90)" >
+						<value >
+							<string >04:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_5_00_AM_91)" >
+						<value >
+							<string >05:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_6_00_AM_92)" >
+						<value >
+							<string >06:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_7_00_AM_93)" >
+						<value >
+							<string >07:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_8_00_AM_94)" >
+						<value >
+							<string >08:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_9_00_AM_95)" >
+						<value >
+							<string >09:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_10_00_AM_96)" >
+						<value >
+							<string >10:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_11_00_AM_97)" >
+						<value >
+							<string >11:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_12_00_PM_98)" >
+						<value >
+							<string >12:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_1_00_PM_99)" >
+						<value >
+							<string >13:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_2_00_PM_100)" >
+						<value >
+							<string >14:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_3_00_PM_101)" >
+						<value >
+							<string >15:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_4_00_PM_102)" >
+						<value >
+							<string >16:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_5_00_PM_103)" >
+						<value >
+							<string >17:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_6_00_PM_104)" >
+						<value >
+							<string >18:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_7_00_PM_105)" >
+						<value >
+							<string >19:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_8_00_PM_106)" >
+						<value >
+							<string >20:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_9_00_PM_107)" >
+						<value >
+							<string >21:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_10_00_PM_108)" >
+						<value >
+							<string >22:00:00</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_11_00_PM_109)" >
+						<value >
+							<string >23:00:00</string>
+						</value>
+					</item>
+				</enum>
+				<enum id="Policy_DropList_Element_Update_Settings_110" valueName="DayOfMonth" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" required="true" >
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_1_111)" >
+						<value >
+							<string >1</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_2_112)" >
+						<value >
+							<string >2</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_3_113)" >
+						<value >
+							<string >3</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_4_114)" >
+						<value >
+							<string >4</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_5_115)" >
+						<value >
+							<string >5</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_6_116)" >
+						<value >
+							<string >6</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_7_117)" >
+						<value >
+							<string >7</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_8_118)" >
+						<value >
+							<string >8</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_9_119)" >
+						<value >
+							<string >9</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_10_120)" >
+						<value >
+							<string >10</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_11_121)" >
+						<value >
+							<string >11</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_12_122)" >
+						<value >
+							<string >12</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_13_123)" >
+						<value >
+							<string >13</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_14_124)" >
+						<value >
+							<string >14</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_15_125)" >
+						<value >
+							<string >15</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_16_126)" >
+						<value >
+							<string >16</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_17_127)" >
+						<value >
+							<string >17</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_18_128)" >
+						<value >
+							<string >18</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_19_129)" >
+						<value >
+							<string >19</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_20_130)" >
+						<value >
+							<string >20</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_21_131)" >
+						<value >
+							<string >21</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_22_132)" >
+						<value >
+							<string >22</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_23_133)" >
+						<value >
+							<string >23</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_24_134)" >
+						<value >
+							<string >24</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_25_135)" >
+						<value >
+							<string >25</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_26_136)" >
+						<value >
+							<string >26</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_27_137)" >
+						<value >
+							<string >27</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_28_138)" >
+						<value >
+							<string >28</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_29_139)" >
+						<value >
+							<string >29</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_30_140)" >
+						<value >
+							<string >30</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_Update_Settings_31_141)" >
+						<value >
+							<string >31</string>
+						</value>
+					</item>
+				</enum>
+
+				<enum id="Policy_DropList_Element_Update_Settings_monthly" valueName="MonthlyScheduleMode" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" required="true" >
+					<item displayName="$(string.Policy_DropList_Element_Update_Settings_monthly_dateofmonth)" >
+						<value >
+							<string >DateOfMonth</string>
+						</value>
+					</item>
+					<item displayName="$(string.Policy_DropList_Element_Update_Settings_monthly_weekdayofmonth)" >
+						<value >
+							<string >WeekDayOfMonth</string>
+						</value>
+					</item>
+				</enum>
+
+				<enum id="Policy_DropList_Element_Update_Settings_monthly_recurrence" valueName="WeekOfMonth" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" required="true" >
+					<item displayName="$(string.Policy_DropList_Element_Update_Settings_monthly_recurrence_first)" >
+						<value >
+							<string >first</string>
+						</value>
+					</item>
+					<item displayName="$(string.Policy_DropList_Element_Update_Settings_monthly_recurrence_second)" >
+						<value >
+							<string >second</string>
+						</value>
+					</item>
+					<item displayName="$(string.Policy_DropList_Element_Update_Settings_monthly_recurrence_third)" >
+						<value >
+							<string >third</string>
+						</value>
+					</item>
+					<item displayName="$(string.Policy_DropList_Element_Update_Settings_monthly_recurrence_fourth)" >
+						<value >
+							<string >fourth</string>
+						</value>
+					</item>
+					<item displayName="$(string.Policy_DropList_Element_Update_Settings_monthly_recurrence_last)" >
+						<value >
+							<string >last</string>
+						</value>
+					</item>
+				</enum>
+
+			</elements>
+		</policy>
+		<policy name="Policy_What_to_do_when_150" class="Machine" displayName="$(string.String_Policy_What_to_do_when_151)" explainText="$(string.String_Explain_When_this_setting_152)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" presentation="$(presentation.Policy_What_to_do_when_150)" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<elements >
+				<enum id="Policy_DropList_Element_What_to_do_when_153" valueName="AutomationMode" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" required="true" >
+					<item displayName="$(string.String_Policy_DropList_Select_What_to_do_when_Notify_only_when_154)" >
+						<value >
+							<string >ScanNotify</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_What_to_do_when_Download_update_155)" >
+						<value >
+							<string >ScanDownloadNotify</string>
+						</value>
+					</item>
+					<item displayName="$(string.String_Policy_DropList_Select_What_to_do_when_Download_and_install_156)" >
+						<value >
+							<string >ScanDownloadApplyNotify</string>
+						</value>
+					</item>
+				</enum>
+			</elements>
+		</policy>
+
+		<policy name="String_Policy_Configure_Deferral_Install" class="Machine" displayName="$(string.String_Policy_Configure_Deferral_Install)" explainText="$(string.String_Policy_Configure_Deferral_Install_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" presentation="$(presentation.Policy_Configure_deferral_install_placeholder)" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" valueName="InstallationDeferral" >
+					<value >
+						<decimal value="1" />
+					</value>
+				</item>
+			</enabledList>
+
+			<disabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" valueName="InstallationDeferral" >
+					<value >
+						<decimal value="0" />
+					</value>
+				</item>
+			</disabledList>
+			<elements >
+				<decimal id="Installation_Deferral_Interval" valueName="DeferralInstallInterval" minValue="1" maxValue="99" required="true" />
+				<decimal id="Installation_Deferral_Count" valueName="DeferralInstallCount" minValue="1" maxValue="9" required="true" />
+			</elements>
+		</policy>
+
+		<policy name="String_Policy_Configure_Deferral_Restart" class="Machine" displayName="$(string.String_Policy_Configure_Deferral_Restart)" explainText="$(string.String_Policy_Configure_Deferral_Restart_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" presentation="$(presentation.Policy_Configure_deferral_restart_placeholder)" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" valueName="SystemRestartDeferral" >
+					<value >
+						<decimal value="1" />
+					</value>
+				</item>
+			</enabledList>
+
+			<disabledList >
+				<item key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\Schedule" valueName="SystemRestartDeferral" >
+					<value >
+						<decimal value="0" />
+					</value>
+				</item>
+			</disabledList>
+			<elements >
+				<decimal id="System_Restart_Deferral_Interval" valueName="DeferRestartInterval" minValue="1" maxValue="99" required="true" />
+				<decimal id="System_Restart_Deferral_Count" valueName="DeferRestartCount" minValue="1" maxValue="9" required="true" />
+			</elements>
+		</policy>
+
+		<policy name="Policy_Configure_delay_days" class="Machine" displayName="$(string.String_Policy_Delay_Days)" explainText="$(string.String_Policy_Delay_Days_text)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\General" presentation="$(presentation.Policy_Configure_delay_days)" >
+			<parentCategory ref="Cat_Update_Settings_9" />
+			<supportedOn ref="SupportedOn_1" />
+			<elements>
+				<decimal id="Delay_days_Interval" valueName="ExcludeUpdatesFromLastNDays" minValue="0" maxValue="45" required="true" />
+			</elements>
+		</policy>
+
+		<policy name="Policy_Hardware_Drivers_157" class="Machine" displayName="$(string.String_Policy_Hardware_Drivers_158)" explainText="$(string.String_Explain_When_this_setting_159)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\UpdateType" valueName="IsDriverSelected" >
+			<parentCategory ref="Cat_Update_Types_11" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Application_Software_160" class="Machine" displayName="$(string.String_Policy_Application_Software_161)" explainText="$(string.String_Explain_When_this_setting_162)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\UpdateType" valueName="IsApplicationSelected" >
+			<parentCategory ref="Cat_Update_Types_11" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_BIOS_Updates_163" class="Machine" displayName="$(string.String_Policy_BIOS_Updates_164)" explainText="$(string.String_Explain_When_this_setting_165)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\UpdateType" valueName="IsBiosSelected" >
+			<parentCategory ref="Cat_Update_Types_11" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Firmware_Updates_166" class="Machine" displayName="$(string.String_Policy_Firmware_Updates_167)" explainText="$(string.String_Explain_When_this_setting_168)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\UpdateType" valueName="IsFirmwareSelected" >
+			<parentCategory ref="Cat_Update_Types_11" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_Utility_Software_169" class="Machine" displayName="$(string.String_Policy_Utility_Software_170)" explainText="$(string.String_Explain_When_this_setting_171)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\UpdateType" valueName="IsUtilitySelected" >
+			<parentCategory ref="Cat_Update_Types_11" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+		<policy name="Policy_All_Others_172" class="Machine" displayName="$(string.String_Policy_All_Others_173)" explainText="$(string.String_Explain_When_this_setting_174)" key="SOFTWARE\Policies\Dell\UpdateService\Clients\CommandUpdate\Preferences\Settings\UpdateFilter\UpdateType" valueName="IsUpdateTypeOtherSelected" >
+			<parentCategory ref="Cat_Update_Types_11" />
+			<supportedOn ref="SupportedOn_1" />
+			<enabledValue >
+				<decimal value="1" />
+			</enabledValue>
+			<disabledValue >
+				<decimal value="0" />
+			</disabledValue>
+		</policy>
+	</policies>
+</policyDefinitions>

--- a/Dell Command Update/Dell.admx
+++ b/Dell Command Update/Dell.admx
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<policyDefinitions revision="1.0" schemaVersion="1.0">
+  <policyNamespaces>
+    <target namespace="Dell.Policies" prefix="Dell"/>
+  </policyNamespaces>
+  <resources minRequiredRevision="1.0" />
+  <categories>
+    <category displayName="$(string.dell)" name="Cat_Dell"/>
+  </categories>
+</policyDefinitions>

--- a/Dell Command Update/en-US/Dell Command Update.adml
+++ b/Dell Command Update/en-US/Dell Command Update.adml
@@ -1,0 +1,264 @@
+<?xml version="1.0"?>
+<!-- 
+/* DELL PROPRIETARY INFORMATION
+*
+* This software contains the intellectual property of Dell Inc. Use of this software and the intellectual property
+* contained therein is expressly limited to the terms and conditions of the License Agreement under which it is
+* provided by or on behalf of Dell Inc. or its subsidiaries.
+*
+* Copyright 2023-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+* 
+*  DELL INC. MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF THE SOFTWARE, EITHER
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.  DELL SHALL NOT BE LIABLE FOR ANY DAMAGES * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+* DERIVATIVES.
+*/
+-->
+<policyDefinitionResources revision="1.0" schemaVersion="1.0" >
+<displayName >Enter Display Name here</displayName>
+	<description >Dell Command Update</description>
+	<resources >
+		<stringTable ><!--Storage for String Definitions-->
+
+			<string id="String_SupportedOn_Windows_10_Windows_2" >Windows 10, Windows 11</string>
+			<string id="String_SupportedOn_Undefined_179" >Undefined</string>
+			<string id="String_Dell_Command_Update" >Dell Command Update</string>
+			<string id="String_Cat_Dell_Command_Update_4" >Dell Command Update</string>
+			<string id="String_Cat_Device_Category_6" >Device Category</string>
+			<string id="String_Cat_Recommended_Levels_8" >Recommended Levels</string>
+			<string id="String_Cat_Update_Settings_10" >Update Settings</string>
+			<string id="String_Cat_Update_Types_12" >Update Types</string>
+			<string id="String_Policy_Enable_Lock_Settings_17" >Enable Lock Settings</string>
+			<string id="String_Explain_When_this_setting_18" >When this setting is enabled, the end user will not be able to change any DCU Configuration settings</string>
+			<string id="String_Policy_Enable_User_Consent_23" >Enable User Consent</string>
+			<string id="String_Policy_Allow_Catalog_xml" >Allow Catalog XML Files</string>
+			<string id="String_Explain_When_this_setting_24" >When this setting is enabled, Dell will collect usage information for the purpose of improving its products and services.</string>
+			<string id="String_Policy_Allow_Catalog_xml_text" >When this setting is enabled, it enables Catalog XML Files.</string>
+			<string id="String_Policy_Enable_the_Default_181" >Enable the Default Dell Catalog</string>
+			<string id="String_Explain_When_this_setting_182" >When this setting is enabled, Dell Command Update will use the default Dell Catalog for updates. When it is disabled, you will need to specify a custom catalog for Dell Command Update to use. If you disable this, without specify a custom catalog XML file, DCU will not work.</string>
+			<string id="String_Policy_Enable_Autosuspend_26" >Enable Autosuspend bitlocker</string>
+			<string id="String_Policy_Proxy_fallback" >Use internet connection if proxy fails</string>
+			<string id="String_Policy_Proxy_fallback_text" >Use internet connection if proxy fails, Applicable only when Proxy settings are configured.</string>
+			<string id="String_Explain_When_this_setting_27" >When this setting is enabled, you can set BitLocker to be suspended during BIOS updates. Note: BIOS updates will be blocked on BitLocker encrypted drives if this not enabled</string>
+			<string id="String_Policy_Set_the_Download_29" >Set the Download Path</string>
+			<string id="String_Policy_Configure_Driver_Library" >Configure Driver Library</string>
+			<string id="String_Policy_Configure_Driver_Library_text" >Set the Driver Library Path(No restricted paths should be added)</string>
+			<string id="String_Policy_Configure_Proxy" >Configure Proxy Server</string>
+			<string id="String_Policy_Configure_Proxy_text" >Configure Proxy Server</string>
+			<string id="String_Policy_Configure_Proxy_port" >Configure Proxy Port</string>
+			<string id="String_Policy_Configure_Proxy_port_text" >You need to enable "Configure Proxy server" setting before configuring the proxy port range(0-65535)</string>
+			<string id="String_Policy_Configure_Proxy_auth" >Configure Proxy Authentication</string>
+			<string id="String_Policy_Configure_Proxy_auth_text" >Configure Proxy Authentication(Username)</string>
+			<string id="String_Policy_Disable_ADR" >Disable ADR</string>
+			<string id="String_Policy_Disable_ADR_text" >When this setting is enabled, Advanced Driver Restore does not appear below Driver Updates on the Welcome Screen</string>
+			<string id="String_Policy_Disable_Notifications" >Disable Notifications</string>
+			<string id="String_Policy_Disable_Notifications_text" >Supress all notifications except mandatory scheduled reboot</string>
+			<string id="String_Policy_Mandatory_Reboot" >Reboot after updates are installed</string>
+			<string id="String_Policy_Mandatory_Reboot_text" >Force reboot after applying updates. To configure this, you need to set "What to do when updates are found" to "Download and install updates(Notify after complete)"</string>
+			<string id="String_Policy_Filter_Applicable_Mode" >What Updates to display</string>
+            <string id="String_Policy_Filter_Applicable_Mode_text" >Filter Recommended Updates or All Applicable Updates</string>
+			<string id="String_Policy_Maximum_Retry_Attempts" >Maximum Retry Attempts</string>
+			<string id="String_Policy_Maximum_Retry_Attempts_text" >Retry attempts to install failed updates (Applicable to both manual and scheduled activity)</string>
+			<string id="String_Explain_Change_where_the_30" >Change where the update files are stored. Note: files are automatically deleted from this location after installation.(No restricted paths should be added)</string>
+			<string id="String_Policy_Chipset_Drivers_37" >Chipset Drivers</string>
+			<string id="String_Explain_When_this_setting_38" >When this setting is enabled, Chipset drivers will be included</string>
+			<string id="String_Policy_Storage_e_g_Hard_40" >Storage (e.g. Hard drive, CD/DVD) Drivers</string>
+			<string id="String_Explain_When_this_setting_41" >When this setting is enabled, Storage drivers will be included</string>
+			<string id="String_Policy_Video_Drivers_43" >Video Drivers</string>
+			<string id="String_Explain_When_this_setting_44" >When this setting is enabled, Video drivers will be included</string>
+			<string id="String_Policy_Input_e_g_Mouse_46" >Input (e.g. Mouse, Keyboard) Drivers</string>
+			<string id="String_Explain_When_this_setting_47" >When this setting is enabled, Input drivers will be included</string>
+			<string id="String_Policy_Audio_Drivers_49" >Audio Drivers</string>
+			<string id="String_Explain_When_this_setting_50" >When this setting is enabled, Audio drivers will be included</string>
+			<string id="String_Policy_Network_Drivers_52" >Network Drivers</string>
+			<string id="String_Explain_When_this_setting_53" >When this setting is enabled, Network drivers will be included</string>
+			<string id="String_Policy_All_Others_55" >All Others</string>
+			<string id="String_Explain_When_this_setting_56" >When this setting is enabled, All Other drivers will be included</string>
+			<string id="String_Policy_Security_Updates_58" >Security Updates</string>
+			<string id="String_Explain_When_this_setting_59" >When this setting is enabled, Security Updates will be included</string>
+			<string id="String_Policy_Recommended_Updates_61" >Recommended Updates</string>
+			<string id="String_Explain_When_this_setting_62" >When this setting is enabled, Recommended Updates will be included</string>
+			<string id="String_Policy_Optional_Updates_64" >Optional Updates</string>
+			<string id="String_Explain_When_this_setting_65" >When this setting is enabled, Optional Updates will be included</string>
+			<string id="String_Policy_Critical_Updates_67" >Critical Updates</string>
+			<string id="String_Explain_When_this_setting_68" >When this setting is enabled, Critical Updates will be included</string>
+			<string id="String_Policy_Update_Settings_70" >Update Settings</string>
+			<string id="String_Explain_When_this_setting_71" >When this setting is enabled, you can set the update schedule. If left &quot;Not configured&quot; the default is Automatic updates</string>
+			<string id="String_Policy_DropList_Filter_ShowOnlyForSystemConfig" >Updates for this system configuration(Recommended)</string>
+			<string id="String_Policy_DropList_Filter_ShowAllForPlatform" >All Updates for System Model</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Manual_Updates_73" >Manual Updates</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Automatic_Updates_74" >Automatic Updates</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Daily" >Daily</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Weekly_75" >Weekly</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Monthly_76" >Monthly</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Sunday_78" >Sunday</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Monday_79" >Monday</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Tuesday_80" >Tuesday</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Wednesday_81" >Wednesday</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Thursday_82" >Thursday</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Friday_83" >Friday</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_Saturday_84" >Saturday</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_12_00_AM_DEFAULT_86" >12:00 AM&quot; DEFAULT</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_1_00_AM_87" >1:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_2_00_AM_88" >2:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_3_00_AM_89" >3:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_4_00_AM_90" >4:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_5_00_AM_91" >5:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_6_00_AM_92" >6:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_7_00_AM_93" >7:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_8_00_AM_94" >8:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_9_00_AM_95" >9:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_10_00_AM_96" >10:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_11_00_AM_97" >11:00 AM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_12_00_PM_98" >12:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_1_00_PM_99" >1:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_2_00_PM_100" >2:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_3_00_PM_101" >3:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_4_00_PM_102" >4:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_5_00_PM_103" >5:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_6_00_PM_104" >6:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_7_00_PM_105" >7:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_8_00_PM_106" >8:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_9_00_PM_107" >9:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_10_00_PM_108" >10:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_11_00_PM_109" >11:00 PM</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_1_111" >1</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_2_112" >2</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_3_113" >3</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_4_114" >4</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_5_115" >5</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_6_116" >6</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_7_117" >7</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_8_118" >8</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_9_119" >9</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_10_120" >10</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_11_121" >11</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_12_122" >12</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_13_123" >13</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_14_124" >14</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_15_125" >15</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_16_126" >16</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_17_127" >17</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_18_128" >18</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_19_129" >19</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_20_130" >20</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_21_131" >21</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_22_132" >22</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_23_133" >23</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_24_134" >24</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_25_135" >25</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_26_136" >26</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_27_137" >27</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_28_138" >28</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_29_139" >29</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_30_140" >30</string>
+			<string id="String_Policy_DropList_Select_Update_Settings_31_141" >31</string>
+			<string id="String_Policy_What_to_do_when_151" >What to do when updates are found</string>
+			<string id="String_Policy_Configure_Deferral_Install" >Installation Deferral </string>
+			<string id="String_Policy_Configure_Deferral_Restart" >System Restart Deferral </string>
+			<string id="String_Policy_Configure_Deferral_Install_text" >To configure Installation Deferral Settings, you need to set "What to do when updates are found" to "Download and install updates(Notify after complete)" and set the "Disable Notifications" setting to Disabled/Not Configured state</string>
+			<string id="String_Policy_Configure_Deferral_Restart_text" >To configure System Restart Deferral Settings, you need to set "What to do when updates are found" to "Download and install updates(Notify after complete)" state</string>
+			<string id="String_Explain_When_this_setting_152" >When this setting is enabled you can configure what happens when updates are found</string>
+			<string id="String_Policy_DropList_Select_What_to_do_when_Notify_only_when_154" >Notify only (when updates are available)</string>
+			<string id="String_Policy_DropList_Select_What_to_do_when_Download_update_155" >Download update (Notify when ready to install)</string>
+			<string id="String_Policy_DropList_Select_What_to_do_when_Download_and_install_156" >Download and install updates (Notify after complete)</string>
+			<string id="String_Policy_Hardware_Drivers_158" >Hardware Drivers</string>
+			<string id="String_Policy_DropList_Select_Maximum_Retry_Attempts_1" >1</string>
+			<string id="String_Policy_DropList_Select_Maximum_Retry_Attempts_2" >2</string>
+			<string id="String_Policy_DropList_Select_Maximum_Retry_Attempts_3" >3</string>
+			<string id="String_Policy_Delay_Days" >Delay Days</string>
+			<string id="String_Policy_Delay_Days_text" >Show Updates Older Than [X] Days</string>
+			<string id="String_Explain_When_this_setting_159" >When this setting is enabled, Hardware updates will be included</string>
+			<string id="String_Policy_Application_Software_161" >Application Software (e.g. Dell Command | Update)</string>
+			<string id="String_Explain_When_this_setting_162" >When this setting is enabled, Application Updates will be included</string>
+			<string id="String_Policy_BIOS_Updates_164" >BIOS Updates</string>
+			<string id="String_Explain_When_this_setting_165" >When this setting is enabled, BIOS Updates will be included</string>
+			<string id="String_Policy_Firmware_Updates_167" >Firmware Updates</string>
+			<string id="String_Explain_When_this_setting_168" >When this setting is enabled, Firmware will be included</string>
+			<string id="String_Policy_Utility_Software_170" >Utility Software</string>
+			<string id="String_Explain_When_this_setting_171" >When this setting is enabled, Utility Software will be included</string>
+			<string id="String_Policy_All_Others_173" >All Others</string>
+			<string id="String_Explain_When_this_setting_174" >When this setting is enabled, All Other updates will be included</string>
+			<string id="Policy_DropList_Element_Update_Settings_monthly_dateofmonth" >Date of Month</string>
+			<string id="Policy_DropList_Element_Update_Settings_monthly_weekdayofmonth" >Week and Day of Month</string>
+			<string id="Policy_DropList_Element_Update_Settings_monthly_recurrence_first" >First</string>
+			<string id="Policy_DropList_Element_Update_Settings_monthly_recurrence_second" >Second</string>
+			<string id="Policy_DropList_Element_Update_Settings_monthly_recurrence_third" >Third</string>
+			<string id="Policy_DropList_Element_Update_Settings_monthly_recurrence_fourth" >Fourth</string>
+			<string id="Policy_DropList_Element_Update_Settings_monthly_recurrence_last" >Last</string>
+		</stringTable>
+		<presentationTable ><!--Storage for Presentation Definitions-->
+
+			<presentation id="Policy_Set_the_Download_28" >
+				<textBox refId="Policy_TextBox_Element_Set_the_Download_31" >
+					<label >Enter the path here</label>
+					<defaultValue >C:\ProgramData\Dell\UpdateService\Downloads</defaultValue>
+				</textBox>
+			</presentation>
+
+			<presentation id="Policy_Configure_Driver_library" >
+				<textBox refId="Policy_TextBox_Element_Configure_driver_library_path" >
+					<label >Enter the path here(CAB/EXE files should be provided)</label>
+				</textBox>
+			</presentation>
+			<presentation id="Policy_Update_Filter" >
+                <dropdownList refId="Policy_DropList_Element_Filter_Applicable_Mode" defaultItem="0" noSort="true">What to display:</dropdownList>
+			</presentation>
+			<presentation id="Policy_Update_Settings_69" >
+				<dropdownList refId="Policy_DropList_Element_Update_Settings_72" defaultItem="0" noSort="true">Select the update interval:</dropdownList>
+				<dropdownList refId="Policy_DropList_Element_Update_Settings_85" defaultItem="0" noSort="true">Select the time of day to start updates (Only applies when selecting &quot;Daily&quot; or &quot;Weekly&quot; or &quot;Monthly&quot; for the update interval)</dropdownList>
+				<dropdownList refId="Policy_DropList_Element_Update_Settings_110" defaultItem="0" noSort="true">Select the day of Month (Only Applicable for &quot;Monthly&quot; option(Date of Month))</dropdownList>
+				<dropdownList refId="Policy_DropList_Element_Update_Settings_monthly" defaultItem="0" noSort="true">Select the Recurrence type(Only Applicable for &quot;Monthly&quot; options(Default is date of Month))</dropdownList>
+				<dropdownList refId="Policy_DropList_Element_Update_Settings_monthly_recurrence" defaultItem="0" noSort="true">Select the recurrence pattern(Only Applicable for &quot;Monthly&quot; options) Note: Reccurence Type should be selected to &quot;Week and Day of month&quot; to apply)</dropdownList>
+				<dropdownList refId="Policy_DropList_Element_Update_Settings_77" defaultItem="0" noSort="true">Select the day of the week to perform updates (Only required when selecting &quot;Weekly&quot; or Reccurence type(&quot;Week and Day of month&quot;) opted in &quot;Monthly&quot;)</dropdownList>
+
+			</presentation>
+			<presentation id="Policy_What_to_do_when_150" >
+				<dropdownList refId="Policy_DropList_Element_What_to_do_when_153" defaultItem="0" noSort="true">Select what to do when updates are found</dropdownList>
+			</presentation>
+			<presentation id="Policy_Configure_deferral_install_placeholder" >
+
+				 <text>Installation Deferral Interval(Hours(1-99))</text>
+				<decimalTextBox refId="Installation_Deferral_Interval"></decimalTextBox>
+				
+				 <text>Installation Deferral Count(1-9)</text>
+				<decimalTextBox refId="Installation_Deferral_Count"></decimalTextBox>
+
+			</presentation>
+			<presentation id="Policy_Configure_deferral_restart_placeholder" >
+			
+				<text>System Restart Deferral Interval(Hours(1-99))</text>
+				<decimalTextBox refId="System_Restart_Deferral_Interval"></decimalTextBox>
+				
+				<text>System Restart Deferral Count(1-9)</text>
+				<decimalTextBox refId="System_Restart_Deferral_Count"></decimalTextBox>
+
+			</presentation>
+			<presentation id="Policy_Configure_delay_days" >
+				<text>Delay Days Interval(Days(0-45))</text>
+				<decimalTextBox refId="Delay_days_Interval" defaultValue="0"></decimalTextBox>
+
+			</presentation>
+			<presentation id="Policy_Configure_proxy_placeholder" >
+				<textBox refId="Policy_TextBox_Element_Configure_proxy_server">
+				  <label>Proxy Server:</label>
+				</textBox>
+			</presentation>	
+			
+			<presentation id="Policy_Configure_proxy_port_placeholder" >
+				<text>Proxy port (Range(0-65535))</text>
+				<decimalTextBox refId="Policy_TextBox_Element_Configure_proxy_port"></decimalTextBox>			
+			</presentation>	
+			
+			<presentation id="Configure_proxy_authentication_placeholder" >
+				<textBox refId="Policy_TextBox_Element_Configure_proxy_auth_username">
+				  <label>Proxy Settings should be configured to use authentication. Proxy Username:</label>
+				</textBox>			
+			</presentation>
+			
+			
+			<presentation id="Policy_Maximum_Retry_Attempts_dropdown" >
+				<dropdownList refId="Policy_DropList_Element_Maximum_Retry_Attempts" defaultItem="1" noSort="true">Select the number of retry attempts to install failed updates</dropdownList>
+			</presentation>
+		</presentationTable>
+	</resources></policyDefinitionResources>

--- a/Dell Command Update/en-US/Dell.adml
+++ b/Dell Command Update/en-US/Dell.adml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+  <displayName/>
+  <description/>
+  <resources>
+    <stringTable>
+      <string id="dell">Dell</string>
+    </stringTable>
+  </resources>
+</policyDefinitionResources>

--- a/EvergreenAdmx.ps1
+++ b/EvergreenAdmx.ps1
@@ -3,13 +3,7 @@
 #region init
 <#PSScriptInfo
 
-.VERSION 2411.1
-
-.GUID 999952b7-1337-4018-a1b9-499fad48e734
-
 .AUTHOR Arjan Mensch & Jonathan Pitre
-
-.COMPANYNAME IT-WorXX
 
 .TAGS GroupPolicy GPO Admx Evergreen Automation
 
@@ -24,127 +18,172 @@
 
 .DESCRIPTION
     Script to automatically download latest Admx files for several products.
-    Optionally copies the latest Admx files to a folder of your chosing, for example a Policy Store.
+    Optionally copies the latest Admx files to a folder of your choosing, for example a Policy Store.
 
-.PARAMETER Windows10Version
-    The Windows 10 version to get the Admx files for. This value will be ignored if 'Windows 10' is
-    not specified with -Include parameter.
-    If the -Include parameter contains 'Windows 10', the latest Windows 10 version will be used.
-    Defaults to "Windows11Version" if omitted.
+.PARAMETER WindowsVersion
+    Specifies Windows major version. Supports 10, 11 or 2025. Default is 11.
 
- Note: Windows 11 23H2 policy definitions now supports Windows 10.
+.PARAMETER Windows10FeatureVersion
+    Specifies Windows 10 feature version to get the Admx files for. This parameter is used when 'Windows 10' is included.
+    Valid values are: 1903, 1909, 2004, 20H2, 21H1, 21H2, 22H2.
+    Defaults to 22H2.
 
-.PARAMETER Windows11Version
-    The Windows 11 version to get the Admx files for. This value will be ignored if 'Windows 10' is
-    not specified with -Include parameter.
-    If omitted, defaults to latest version available .
+    Note: Windows 11 23H2 policy definitions now supports Windows 10.
+
+.PARAMETER Windows11FeatureVersion
+    Specifies Windows 11 feature version to get the Admx files for. This parameter is used when 'Windows 11' is included.
+    Valid values are: 21H2, 22H2, 23H2, 24H2.
+    Defaults to 24H2.
 
 .PARAMETER WorkingDirectory
-    Optionally provide a Working Directory for the script.
-    The script will store Admx files in a subdirectory called "admx".
-    The script will store downloaded files in a subdirectory called "downloads".
+    Specifies a Working Directory for the script.
+    Admx files will be stored in a subdirectory called "admx".
+    Downloaded files will be stored in a subdirectory called "downloads".
     If omitted the script will treat the script's folder as the working directory.
 
 .PARAMETER PolicyStore
-    Optionally provide a Policy Store location to copy the Admx files to after processing.
+    Specifies a Policy Store location to copy the Admx files to after processing.
 
 .PARAMETER Languages
-    Optionally provide an array of languages to process. Entries must be in 'xy-XY' format.
-    If omitted the script will default to 'en-US'.
+    Specifies an array of languages to process. Entries must be in 'xy-XY' format.
+    Defaults to 'en-US'.
 
 .PARAMETER UseProductFolders
-    When specified the extracted Admx files are copied to their respective product folders in a subfolder of 'Admx' in the WorkingDirectory.
+    Admx files are copied to their respective product folders in a subfolder of 'Admx' in the WorkingDirectory.
 
-.PARAMETER CustomPolicyStore
-    When specified processes a location for custom policy files. Can be UNC format or local folder.
-    The script will expect to find .admx files in this location, and at least one language folder holding the .adml file(s).
+.PARAMETER AddAdmxPath
+    Specifies a location for custom policy files. Can be UNC format or local folder.
+    Find .admx files in this location, and at least one language folder holding the .adml file(s).
     Versioning will be done based on the newest file found recursively in this location (any .admx or .adml).
     Note that if any file has changed the script will process all files found in location.
 
 .PARAMETER Include
     Array containing Admx products to include when checking for updates.
-    Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office" if omitted.
+    Valid values are: "Windows 10", "Windows 11", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
+    Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps".
 
 .PARAMETER PreferLocalOneDrive
     Microsoft OneDrive Admx files are only available after installing OneDrive.
-    If this script is running on a machine that has OneDrive installed, this switch will prevent automatic uninstallation of OneDrive.
+    If this script is running on a machine that has OneDrive installed locally, use this switch to prevent automatically uninstalling OneDrive.
+
+.EXAMPLE
+    .\EvergreenAdmx.ps1
+
+    Downloads the latest admx files for Windows 11, Microsoft Edge, Microsoft OneDrive, and Microsoft 365 Apps to the current folder.
+
+.EXAMPLE
+    .\EvergreenAdmx.ps1 -WorkingDirectory "C:\Temp\EvergreenAdmx" -Include @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps', 'Microsoft FSLogix')
+
+    Downloads the latest admx files for the specified products to C:\Temp\EvergreenAdmx folder.
+
+.EXAMPLE
+    .\EvergreenAdmx.ps1 -WindowsVersion 2025 -Include "Windows 2025"
+
+    Downloads the latest admx files for Windows 2025 to the current folder.
 
 .EXAMPLE
     .\EvergreenAdmx.ps1 -PolicyStore "C:\Windows\SYSVOL\domain\Policies\PolicyDefinitions" -Languages @("en-US", "nl-NL") -UseProductFolders
-    Get policy default set of products, storing results in product folders, for both en-us and nl-NL languages, and copies the files to the Policy store.
+
+    Downloads the default set of admx files, stores them in product folders for both English and Dutch languages, and copies them to the specified Policy store.
 
 .LINK
     https://github.com/msfreaks/EvergreenAdmx
     https://msfreaks.wordpress.com
-
 #>
 
-[CmdletBinding(DefaultParameterSetName = 'Windows11Version')]
+[CmdletBinding()]
 param(
-    [Parameter(Mandatory = $False, ParameterSetName = "Windows10Version", Position = 0)][ValidateSet("1903", "1909", "2004", "20H2", "21H1", "21H2", "22H2")]
-    [System.String] $Windows10Version = "22H2",
-    [Parameter(Mandatory = $False, ParameterSetName = "Windows11Version", Position = 0)][ValidateSet("21H2", "22H2", "23H2", "24H2")]
-    [Alias("WindowsVersion")]
-    [System.String] $Windows11Version = "24H2",
+    [Parameter(Mandatory = $False, Position = 0)]
+    [ValidateSet('10', '11', '2025')]
+    [System.String] $WindowsVersion = '11',
+    [Parameter(Mandatory = $False)][ValidateSet('1903', '1909', '2004', '20H2', '21H1', '21H2', '22H2')]
+    [System.String] $Windows10FeatureVersion = '22H2',
+    [Parameter(Mandatory = $False)][ValidateSet('21H2', '22H2', '23H2', '24H2')]
+    [Alias('WindowsFeatureEdition')]
+    [System.String] $Windows11FeatureVersion = '24H2',
     [Parameter(Mandatory = $False)]
-    [System.String] $WorkingDirectory = $null,
+    [System.String] $WorkingDirectory,
     [Parameter(Mandatory = $False)]
     [System.String] $PolicyStore = $null,
     [Parameter(Mandatory = $False)]
-    [System.String[]] $Languages = @("en-US"),
+    [System.String[]] $Languages = @('en-US'),
     [Parameter(Mandatory = $False)]
     [switch] $UseProductFolders,
     [Parameter(Mandatory = $False)]
-    [System.String] $CustomPolicyStore = $null,
-    [Parameter(Mandatory = $False)][ValidateSet("Custom Policy Store", "Windows 10", "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office", "FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client", "Azure Virtual Desktop", "Microsoft Winget")]
-    [System.String[]] $Include = @("Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office"),
+    [Alias('CustomPolicyStore')]
+    [System.String] $AddAdmxPath = $null,
+    [Parameter(Mandatory = $False)]
+    [ValidateSet('Custom Policy Store', 'Windows 10', 'Windows 11', 'Windows 2025', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps', 'Microsoft FSLogix', 'Adobe Acrobat', 'Adobe Reader', 'BIS-F', 'Citrix Workspace App', 'Google Chrome', 'Microsoft Desktop Optimization Pack', 'Mozilla Firefox', 'Zoom', 'Zoom VDI', 'Microsoft AVD', 'Microsoft Winget', 'Brave Browser')]
+    [System.String[]] $Include = @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps'),
     [Parameter(Mandatory = $False)]
     [switch] $PreferLocalOneDrive = $False
 )
-$ProgressPreference = "SilentlyContinue"
-$ErrorActionPreference = "SilentlyContinue"
 
-$admxversions = $null
-if (-not $WorkingDirectory) { $WorkingDirectory = $PSScriptRoot }
-if (Test-Path -Path "$($WorkingDirectory)\admxversions.xml") { $admxversions = Import-Clixml -Path "$($WorkingDirectory)\admxversions.xml" }
+# Validate feature version based on Windows version
+if ($WindowsVersion -eq '10' -and $PSBoundParameters.ContainsKey('Windows11FeatureVersion')) {
+    Write-Warning 'Windows11FeatureVersion parameter is ignored when WindowsVersion is set to 10'
+} elseif ($WindowsVersion -eq '11' -and $PSBoundParameters.ContainsKey('Windows10FeatureVersion')) {
+    Write-Warning 'Windows10FeatureVersion parameter is ignored when WindowsVersion is set to 11'
+} elseif ($WindowsVersion -eq '2025' -and ($PSBoundParameters.ContainsKey('Windows10FeatureVersion') -or $PSBoundParameters.ContainsKey('Windows11FeatureVersion'))) {
+    Write-Warning 'Windows feature version parameters are ignored when WindowsVersion is set to 2025'
+}
+
+# Set the appropriate feature version variable based on Windows version
+$WindowsFeatureVersion = switch ($WindowsVersion) {
+    '10' { $Windows10FeatureVersion }
+    '11' { $Windows11FeatureVersion }
+    default { $null }
+}
+
+$ProgressPreference = 'SilentlyContinue'
+#$ErrorActionPreference = 'SilentlyContinue'
+
+$AdmxVersions = $null
+If ($WindowsVersion -eq '10' -and $Include -notcontains 'Windows 10') {
+    $Include += 'Windows 10'
+} elseif ($WindowsVersion -eq '11' -and $Include -notcontains 'Windows 11') {
+    $Include += 'Windows 11'
+} elseif ($WindowsVersion -eq '2025' -and $Include -notcontains 'Windows 2025') {
+    $Include += 'Windows 2025'
+}
+if (-not $WorkingDirectory) { $WorkingDirectory = $PWD }
+if (Test-Path -Path "$($WorkingDirectory)\AdmxVersions.xml") { $AdmxVersions = Import-Clixml -Path "$($WorkingDirectory)\AdmxVersions.xml" }
 if (-not (Test-Path -Path "$($WorkingDirectory)\admx")) { $null = New-Item -Path "$($WorkingDirectory)\admx" -ItemType Directory -Force }
 if (-not (Test-Path -Path "$($WorkingDirectory)\downloads")) { $null = New-Item -Path "$($WorkingDirectory)\downloads" -ItemType Directory -Force }
-if ($PolicyStore -and -not $PolicyStore.EndsWith("\")) { $PolicyStore += "\" }
-if ($Languages -notmatch "([A-Za-z]{2})-([A-Za-z]{2})$") { Write-Warning "Language not in expected format: $($Languages -notmatch "([A-Za-z]{2})-([A-Za-z]{2})$")" }
-if ($CustomPolicyStore -and -not (Test-Path -Path "$($CustomPolicyStore)")) { throw "'$($CustomPolicyStore)' is not a valid path." }
-if ($CustomPolicyStore -and -not $CustomPolicyStore.EndsWith("\")) { $CustomPolicyStore += "\" }
-if ($CustomPolicyStore -and (Get-ChildItem -Path $CustomPolicyStore -Directory) -notmatch "([A-Za-z]{2})-([A-Za-z]{2})$") { throw "'$($CustomPolicyStore)' does not contain at least one subfolder matching the language format (e.g 'en-US')." }
-if ($PreferLocalOneDrive -and $Include -notcontains "Microsoft OneDrive") { Write-Warning "PreferLocalOneDrive is used, but Microsoft OneDrive is not in the list of included products to process." }
-$oneDriveADMXFolder = $null
-if ((Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\OneDrive").CurrentVersionPath)
-{
-    $oneDriveADMXFolder = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\OneDrive").CurrentVersionPath
+if ($PolicyStore -and -not $PolicyStore.EndsWith('\')) { $PolicyStore += '\' }
+elseif ($null -eq $PolicyStore) { $PolicyStore = $PWD }
+if ($Languages -notmatch '([A-Za-z]{2})-([A-Za-z]{2})$') { Write-Warning "Language not in expected format: $($Languages -notmatch '([A-Za-z]{2})-([A-Za-z]{2})$')" }
+if ($AddAdmxPath -and -not (Test-Path -Path "$($AddAdmxPath)")) { throw "'$($AddAdmxPath)' is not a valid path." }
+if ($AddAdmxPath -and -not $AddAdmxPath.EndsWith('\')) { $AddAdmxPath += '\' }
+if ($AddAdmxPath -and (Get-ChildItem -Path $AddAdmxPath -Directory) -notmatch '([A-Za-z]{2})-([A-Za-z]{2})$') { throw "'$($AddAdmxPath)' does not contain at least one subfolder matching the language format (e.g 'en-US')." }
+If ($PreferLocalOneDrive -and $Include -notcontains 'Microsoft OneDrive') {
+    $Include += 'Microsoft OneDrive'
 }
-if ((Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\OneDrive").CurrentVersionPath)
-{
-    $oneDriveADMXFolder = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\OneDrive").CurrentVersionPath
+
+# Parameter debugging
+Write-Verbose "Windows Version:`t'$($WindowsVersion)'"
+If ($WindowsVersion -eq '10') {
+    Write-Verbose "Windows Feature Version:`t'$($Windows10FeatureVersion)'"
+} ElseIf ($WindowsVersion -eq '11') {
+    Write-Verbose "Windows Feature Version:`t'$($Windows11FeatureVersion)'"
 }
-if ($PreferLocalOneDrive -and $Include -contains "Microsoft OneDrive" -and $null -eq $oneDriveADMXFolder)
-{
-    throw "PreferLocalOneDrive will only work if OneDrive is machine installed. User installed OneDrive is not supported.`nLocal machine installed OneDrive not found."
-    break
+Write-Verbose "WorkingDirectory:`t'$($WorkingDirectory)'"
+If ($PolicyStore) {
+    Write-Verbose "PolicyStore:`t'$($PolicyStore)'"
 }
-Write-Verbose "Windows 10 Version:`t'$($Windows10Version)'"
-Write-Verbose "Windows 11 Version:`t'$($Windows11Version)'"
-Write-Verbose "WorkingDirectory:`t`t'$($WorkingDirectory)'"
-Write-Verbose "PolicyStore:`t`t`t'$($PolicyStore)'"
-Write-Verbose "CustomPolicyStore:`t`t'$($CustomPolicyStore)'"
-Write-Verbose "Languages:`t`t`t`t'$($Languages)'"
+If ($AddAdmxPath) {
+    Write-Verbose "Add admx Path:`t`'$($AddAdmxPath)'"
+}
+Write-Verbose "Languages:`t`'$($Languages)'"
 Write-Verbose "Use product folders:`t'$($UseProductFolders)'"
-Write-Verbose "Admx path:`t`t`t`t'$($WorkingDirectory)\admx'"
-Write-Verbose "Download path:`t`t`t'$($WorkingDirectory)\downloads'"
-Write-Verbose "Included:`t`t`t`t'$($Include -join ', ')'"
+Write-Verbose "Admx path:`t`'$($WorkingDirectory)\admx'"
+Write-Verbose "Download path:`t`'$($WorkingDirectory)\downloads'"
+Write-Verbose "Included:`t`'$($Include -join ', ')'"
 Write-Verbose "PreferLocalOneDrive:`t'$($PreferLocalOneDrive)'"
 #endregion
 
 #region functions
-function Get-Link
-{
+function Get-Link {
     <#
     .SYNOPSIS
         Returns a specific link from a web page.
@@ -220,38 +259,31 @@ function Get-Link
     $ProgressPreference = 'SilentlyContinue'
 
     $ParamHash = @{
-        Uri              = $Uri
-        Method           = 'GET'
-        UseBasicParsing  = $True
+        Uri = $Uri
+        Method = 'GET'
+        UseBasicParsing = $True
         DisableKeepAlive = $True
-        ErrorAction      = 'Stop'
+        ErrorAction = 'Stop'
     }
 
-    if ($UserAgent)
-    {
+    if ($UserAgent) {
         $ParamHash.UserAgent = $UserAgent
     }
 
-    if ($Headers)
-    {
+    if ($Headers) {
         $ParamHash.Headers = $Headers
     }
 
-    try
-    {
+    try {
         $Response = Invoke-WebRequest @ParamHash
 
-        foreach ($CurrentPattern in $Pattern)
-        {
+        foreach ($CurrentPattern in $Pattern) {
             $Link = $Response.Links | Where-Object $MatchProperty -Match $CurrentPattern | Select-Object -First 1 -ExpandProperty $ReturnProperty
 
-            if ($PrefixDomain)
-            {
+            if ($PrefixDomain) {
                 $BaseURL = ($Uri -split '/' | Select-Object -First 3) -join '/'
                 $Link = Set-UriPrefix -Uri $Link -Prefix $BaseURL
-            }
-            elseif ($PrefixParent)
-            {
+            } elseif ($PrefixParent) {
                 $BaseURL = ($Uri -split '/' | Select-Object -SkipLast 1) -join '/'
                 $Link = Set-UriPrefix -Uri $Link -Prefix $BaseURL
             }
@@ -259,16 +291,13 @@ function Get-Link
             $Link
 
         }
-    }
-    catch
-    {
+    } catch {
         Write-Error "$($MyInvocation.MyCommand): $($_.Exception.Message)"
     }
 
 }
 
-function Get-Version
-{
+function Get-Version {
     <#
     .SYNOPSIS
         Extracts a version number from either a string or the content of a web page using a chosen or pre-defined match pattern.
@@ -334,55 +363,43 @@ function Get-Version
         [Switch] $ReplaceWithDot
     )
 
-    begin
-    {
+    begin {
 
     }
 
-    process
-    {
+    process {
 
-        if ($PsCmdlet.ParameterSetName -eq 'Uri')
-        {
+        if ($PsCmdlet.ParameterSetName -eq 'Uri') {
 
             $ProgressPreference = 'SilentlyContinue'
 
-            try
-            {
+            try {
                 $ParamHash = @{
-                    Uri              = $Uri
-                    Method           = 'GET'
-                    UseBasicParsing  = $True
+                    Uri = $Uri
+                    Method = 'GET'
+                    UseBasicParsing = $True
                     DisableKeepAlive = $True
-                    ErrorAction      = 'Stop'
+                    ErrorAction = 'Stop'
                 }
 
-                if ($UserAgent)
-                {
+                if ($UserAgent) {
                     $ParamHash.UserAgent = $UserAgent
                 }
 
                 $String = (Invoke-WebRequest @ParamHash).Content
-            }
-            catch
-            {
+            } catch {
                 Write-Error "Unable to query URL '$Uri': $($_.Exception.Message)"
             }
 
         }
 
-        foreach ($CurrentString in $String)
-        {
-            if ($ReplaceWithDot)
-            {
+        foreach ($CurrentString in $String) {
+            if ($ReplaceWithDot) {
                 $CurrentString = $CurrentString.Replace('-', '.').Replace('+', '.').Replace('_', '.')
             }
-            if ($CurrentString -match $Pattern)
-            {
+            if ($CurrentString -match $Pattern) {
                 $matches[1]
-            }
-            else
-            {
+            } else {
                 Write-Warning "No version found within $CurrentString using pattern $Pattern"
             }
 
@@ -390,15 +407,12 @@ function Get-Version
 
     }
 
-    end
-    {
+    end {
     }
 
 }
 
-# Replace Get-RedirectedUrl function
-function Resolve-Uri
-{
+function Resolve-Uri {
     <#
     .SYNOPSIS
         Resolves a URI and also returns the filename and last modified date if found.
@@ -446,46 +460,37 @@ function Resolve-Uri
         [System.Collections.Hashtable] $Headers
     )
 
-    begin
-    {
+    begin {
         $ProgressPreference = 'SilentlyContinue'
     }
 
-    process
-    {
+    process {
 
-        foreach ($UriToResolve in $Uri)
-        {
+        foreach ($UriToResolve in $Uri) {
 
-            try
-            {
+            try {
 
                 $ParamHash = @{
-                    Uri              = $UriToResolve
-                    Method           = 'Head'
-                    UseBasicParsing  = $True
+                    Uri = $UriToResolve
+                    Method = 'Head'
+                    UseBasicParsing = $True
                     DisableKeepAlive = $True
-                    ErrorAction      = 'Stop'
+                    ErrorAction = 'Stop'
                 }
 
-                if ($UserAgent)
-                {
+                if ($UserAgent) {
                     $ParamHash.UserAgent = $UserAgent
                 }
 
-                if ($Headers)
-                {
+                if ($Headers) {
                     $ParamHash.Headers = $Headers
                 }
 
                 $Response = Invoke-WebRequest @ParamHash
 
-                if ($IsCoreCLR)
-                {
+                if ($IsCoreCLR) {
                     $ResolvedUri = $Response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
-                }
-                else
-                {
+                } else {
                     $ResolvedUri = $Response.BaseResponse.ResponseUri.AbsoluteUri
                 }
 
@@ -494,48 +499,36 @@ function Resolve-Uri
                 #PowerShell 7 returns each header value as single unit arrays instead of strings which messes with the -match operator coming up, so use Select-Object:
                 $ContentDisposition = $Response.Headers.'Content-Disposition' | Select-Object -First 1
 
-                if ($ContentDisposition -match 'filename="?([^\\/:\*\?"<>\|]+)')
-                {
+                if ($ContentDisposition -match 'filename="?([^\\/:\*\?"<>\|]+)') {
                     $FileName = $matches[1]
                     Write-Verbose "$($MyInvocation.MyCommand): Content-Disposition header found: $ContentDisposition"
                     Write-Verbose "$($MyInvocation.MyCommand): File name determined from Content-Disposition header: $FileName"
-                }
-                else
-                {
+                } else {
                     $Slug = [uri]::UnescapeDataString($ResolvedUri.Split('?')[0].Split('/')[-1])
-                    if ($Slug -match '^[^\\/:\*\?"<>\|]+\.[^\\/:\*\?"<>\|]+$')
-                    {
+                    if ($Slug -match '^[^\\/:\*\?"<>\|]+\.[^\\/:\*\?"<>\|]+$') {
                         Write-Verbose "$($MyInvocation.MyCommand): URI slug is a valid file name: $FileName"
                         $FileName = $Slug
-                    }
-                    else
-                    {
+                    } else {
                         $FileName = $null
                     }
                 }
 
-                try
-                {
+                try {
                     $LastModified = [DateTime]($Response.Headers.'Last-Modified' | Select-Object -First 1)
                     Write-Verbose "$($MyInvocation.MyCommand): Last modified date: $LastModified"
-                }
-                catch
-                {
+                } catch {
                     Write-Verbose "$($MyInvocation.MyCommand): Unable to parse date from last modified header: $($Response.Headers.'Last-Modified')"
                     $LastModified = $null
                 }
 
-            }
-            catch
-            {
+            } catch {
                 Throw "$($MyInvocation.MyCommand): Unable to resolve URI: $($_.Exception.Message)"
             }
 
-            if ($ResolvedUri)
-            {
+            if ($ResolvedUri) {
                 [PSCustomObject]@{
-                    Uri          = $ResolvedUri
-                    FileName     = $FileName
+                    Uri = $ResolvedUri
+                    FileName = $FileName
                     LastModified = $LastModified
                 }
             }
@@ -543,350 +536,12 @@ function Resolve-Uri
         }
     }
 
-    end
-    {
+    end {
     }
 
 }
 
-# Replace Invoke-WebRequest (FASTER DOWNLOADS!)
-function Invoke-Download
-{
-    [CmdletBinding()]
-    param(
-        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
-        [Alias('URI')]
-        [ValidateNotNullOrEmpty()]
-        [string]$URL,
-
-        [Parameter(Position = 1)]
-        [ValidateNotNullOrEmpty()]
-        [string]$Destination = $PWD.Path,
-
-        [Parameter(Position = 2)]
-        [string]$FileName,
-
-        [string[]]$UserAgent = @('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36', 'Googlebot/2.1 (+http://www.google.com/bot.html)'),
-
-        [string]$TempPath = [System.IO.Path]::GetTempPath(),
-
-        [switch]$IgnoreDate,
-        [switch]$BlockFile,
-        [switch]$NoClobber,
-        [switch]$NoProgress,
-        [switch]$PassThru
-    )
-
-    begin
-    {
-        # Required on Windows Powershell only
-        if ($PSEdition -eq 'Desktop')
-        {
-            Add-Type -AssemblyName System.Net.Http
-            Add-Type -AssemblyName System.Web
-        }
-
-        # Enable TLS 1.2 in addition to whatever is pre-configured
-        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-
-        # Create one single client object for the pipeline
-        $HttpClient = New-Object System.Net.Http.HttpClient
-    }
-
-    process
-    {
-
-        Write-Verbose "Requesting headers from URL '$URL'"
-
-        foreach ($UserAgentString in $UserAgent)
-        {
-            $HttpClient.DefaultRequestHeaders.Remove('User-Agent') | Out-Null
-            if ($UserAgentString)
-            {
-                Write-Verbose "Using UserAgent '$UserAgentString'"
-                $HttpClient.DefaultRequestHeaders.Add('User-Agent', $UserAgentString)
-            }
-
-            # This sends a GET request but only retrieves the headers
-            $ResponseHeader = $HttpClient.GetAsync($URL, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).Result
-
-            # Exit the foreach if success
-            if ($ResponseHeader.IsSuccessStatusCode)
-            {
-                break
-            }
-        }
-
-        if ($ResponseHeader.IsSuccessStatusCode)
-        {
-            Write-Verbose 'Successfully retrieved headers'
-
-            if ($ResponseHeader.RequestMessage.RequestUri.AbsoluteUri -ne $URL)
-            {
-                Write-Verbose "URL '$URL' redirects to '$($ResponseHeader.RequestMessage.RequestUri.AbsoluteUri)'"
-            }
-
-            try
-            {
-                $FileSize = $null
-                $FileSize = [int]$ResponseHeader.Content.Headers.GetValues('Content-Length')[0]
-                $FileSizeReadable = switch ($FileSize)
-                {
-                    { $_ -gt 1TB } { '{0:n2} TB' -f ($_ / 1TB); Break }
-                    { $_ -gt 1GB } { '{0:n2} GB' -f ($_ / 1GB); Break }
-                    { $_ -gt 1MB } { '{0:n2} MB' -f ($_ / 1MB); Break }
-                    { $_ -gt 1KB } { '{0:n2} KB' -f ($_ / 1KB); Break }
-                    default { '{0} B' -f $_ }
-                }
-                Write-Verbose "File size: $FileSize bytes ($FileSizeReadable)"
-            }
-            catch
-            {
-                Write-Verbose 'Unable to determine file size'
-            }
-
-            # Try to get the last modified date from the "Last-Modified" header, use error handling in case string is in invalid format
-            try
-            {
-                $LastModified = $null
-                $LastModified = [DateTime]::ParseExact($ResponseHeader.Content.Headers.GetValues('Last-Modified')[0], 'r', [System.Globalization.CultureInfo]::InvariantCulture)
-                Write-Verbose "Last modified: $($LastModified.ToString())"
-            }
-            catch
-            {
-                Write-Verbose 'Last-Modified header not found'
-            }
-
-            if ($FileName)
-            {
-                $FileName = $FileName.Trim()
-                Write-Verbose "Will use supplied filename '$FileName'"
-            }
-            else
-            {
-                # Get the file name from the "Content-Disposition" header if available
-                try
-                {
-                    $ContentDispositionHeader = $null
-                    $ContentDispositionHeader = $ResponseHeader.Content.Headers.GetValues('Content-Disposition')[0]
-                    Write-Verbose "Content-Disposition header found: $ContentDispositionHeader"
-                }
-                catch
-                {
-                    Write-Verbose 'Content-Disposition header not found'
-                }
-                if ($ContentDispositionHeader)
-                {
-                    $ContentDispositionRegEx = @'
-^.*filename\*?\s*=\s*"?(?:UTF-8|iso-8859-1)?(?:'[^']*?')?([^";]+)
-'@
-                    if ($ContentDispositionHeader -match $ContentDispositionRegEx)
-                    {
-                        # GetFileName ensures we are not getting a full path with slashes. UrlDecode will convert characters like %20 back to spaces.
-                        $FileName = [System.IO.Path]::GetFileName([System.Web.HttpUtility]::UrlDecode($matches[1]))
-                        # If any further invalid filename characters are found, convert them to spaces.
-                        [IO.Path]::GetinvalidFileNameChars() | ForEach-Object { $FileName = $FileName.Replace($_, ' ') }
-                        $FileName = $FileName.Trim()
-                        Write-Verbose "Extracted filename '$FileName' from Content-Disposition header"
-                    }
-                    else
-                    {
-                        Write-Verbose 'Failed to extract filename from Content-Disposition header'
-                    }
-                }
-
-                if ([string]::IsNullOrEmpty($FileName))
-                {
-                    # If failed to parse Content-Disposition header or if it's not available, extract the file name from the absolute URL to capture any redirections.
-                    # GetFileName ensures we are not getting a full path with slashes. UrlDecode will convert characters like %20 back to spaces. The URL is split with ? to ensure we can strip off any API parameters.
-                    $FileName = [System.IO.Path]::GetFileName([System.Web.HttpUtility]::UrlDecode($ResponseHeader.RequestMessage.RequestUri.AbsoluteUri.Split('?')[0]))
-                    [IO.Path]::GetinvalidFileNameChars() | ForEach-Object { $FileName = $FileName.Replace($_, ' ') }
-                    $FileName = $FileName.Trim()
-                    Write-Verbose "Extracted filename '$FileName' from absolute URL '$($ResponseHeader.RequestMessage.RequestUri.AbsoluteUri)'"
-                }
-            }
-
-        }
-        else
-        {
-            Write-Verbose 'Failed to retrieve headers'
-        }
-
-        if ([string]::IsNullOrEmpty($FileName))
-        {
-            # If still no filename set, extract the file name from the original URL.
-            # GetFileName ensures we are not getting a full path with slashes. UrlDecode will convert characters like %20 back to spaces. The URL is split with ? to ensure we can strip off any API parameters.
-            $FileName = [System.IO.Path]::GetFileName([System.Web.HttpUtility]::UrlDecode($URL.Split('?')[0]))
-            [System.IO.Path]::GetInvalidFileNameChars() | ForEach-Object { $FileName = $FileName.Replace($_, ' ') }
-            $FileName = $FileName.Trim()
-            Write-Verbose "Extracted filename '$FileName' from original URL '$URL'"
-        }
-
-        $DestinationFilePath = Join-Path $Destination $FileName
-
-        # Exit if -NoClobber specified and file exists.
-        if ($NoClobber -and (Test-Path -LiteralPath $DestinationFilePath -PathType Leaf))
-        {
-            Write-Error 'NoClobber switch specified and file already exists'
-            return
-        }
-
-        # Open the HTTP stream
-        $ResponseStream = $HttpClient.GetStreamAsync($URL).Result
-
-        if ($ResponseStream.CanRead)
-        {
-
-            # Check TempPath exists and create it if not
-            if (-not (Test-Path -LiteralPath $TempPath -PathType Container))
-            {
-                Write-Verbose "Temp folder '$TempPath' does not exist"
-                try
-                {
-                    New-Item -Path $Destination -ItemType Directory -Force | Out-Null
-                    Write-Verbose "Created temp folder '$TempPath'"
-                }
-                catch
-                {
-                    Write-Error "Unable to create temp folder '$TempPath': $_"
-                    return
-                }
-            }
-
-            # Generate temp file name
-            $TempFileName = (New-Guid).ToString('N') + ".tmp"
-            $TempFilePath = Join-Path $TempPath $TempFileName
-
-            # Check Destiation exists and create it if not
-            if (-not (Test-Path -LiteralPath $Destination -PathType Container))
-            {
-                Write-Verbose "Output folder '$Destination' does not exist"
-                try
-                {
-                    New-Item -Path $Destination -ItemType Directory -Force | Out-Null
-                    Write-Verbose "Created output folder '$Destination'"
-                }
-                catch
-                {
-                    Write-Error "Unable to create output folder '$Destination': $_"
-                    return
-                }
-            }
-
-            # Open file stream
-            try
-            {
-                $FileStream = [System.IO.File]::Create($TempFilePath)
-            }
-            catch
-            {
-                Write-Error "Unable to create file '$TempFilePath': $_"
-                return
-            }
-
-            if ($FileStream.CanWrite)
-            {
-                Write-Verbose "Downloading to temp file '$TempFilePath'..."
-
-                $Buffer = New-Object byte[] 64KB
-                $BytesDownloaded = 0
-                $ProgressIntervalMs = 250
-                $ProgressTimer = (Get-Date).AddMilliseconds(-$ProgressIntervalMs)
-
-                while ($true)
-                {
-                    try
-                    {
-                        # Read stream into buffer
-                        $ReadBytes = $ResponseStream.Read($Buffer, 0, $Buffer.Length)
-
-                        # Track bytes downloaded and display progress bar if enabled and file size is known
-                        $BytesDownloaded += $ReadBytes
-                        if (!$NoProgress -and (Get-Date) -gt $ProgressTimer.AddMilliseconds($ProgressIntervalMs))
-                        {
-                            if ($FileSize)
-                            {
-                                $PercentComplete = [System.Math]::Floor($BytesDownloaded / $FileSize * 100)
-                                Write-Progress -Activity "Downloading $FileName" -Status "$BytesDownloaded of $FileSize bytes ($PercentComplete%)" -PercentComplete $PercentComplete
-                            }
-                            else
-                            {
-                                Write-Progress -Activity "Downloading $FileName" -Status "$BytesDownloaded of ? bytes" -PercentComplete 0
-                            }
-                            $ProgressTimer = Get-Date
-                        }
-
-                        # If end of stream
-                        if ($ReadBytes -eq 0)
-                        {
-                            Write-Progress -Activity "Downloading $FileName" -Completed
-                            $FileStream.Close()
-                            $FileStream.Dispose()
-                            try
-                            {
-                                Write-Verbose "Moving temp file to destination '$DestinationFilePath'"
-                                $DownloadedFile = Move-Item -LiteralPath $TempFilePath -Destination $DestinationFilePath -Force -PassThru
-                            }
-                            catch
-                            {
-                                Write-Error "Error moving file from '$TempFilePath' to '$DestinationFilePath': $_"
-                                return
-                            }
-                            if ($IsWindows)
-                            {
-                                if ($BlockFile)
-                                {
-                                    Write-Verbose 'Marking file as downloaded from the internet'
-                                    Set-Content -LiteralPath $DownloadedFile -Stream 'Zone.Identifier' -Value "[ZoneTransfer]`nZoneId=3"
-                                }
-                                else
-                                {
-                                    Unblock-File -LiteralPath $DownloadedFile
-                                }
-                            }
-                            if ($LastModified -and -not $IgnoreDate)
-                            {
-                                Write-Verbose 'Setting Last Modified date'
-                                $DownloadedFile.LastWriteTime = $LastModified
-                            }
-                            Write-Verbose 'Download complete!'
-                            if ($PassThru)
-                            {
-                                $DownloadedFile
-                            }
-                            break
-                        }
-                        $FileStream.Write($Buffer, 0, $ReadBytes)
-                    }
-                    catch
-                    {
-                        Write-Error "Error downloading file: $_"
-                        Write-Progress -Activity "Downloading $FileName" -Completed
-                        $FileStream.Close()
-                        $FileStream.Dispose()
-                        break
-                    }
-                }
-
-            }
-        }
-        else
-        {
-            Write-Error 'Failed to start download'
-        }
-
-        # Reset this to avoid reusing the same name when fed multiple URLs via the pipeline
-        $FileName = $null
-    }
-
-    end
-    {
-        $HttpClient.Dispose()
-    }
-}
-
-function Copy-Admx
-{
+function Copy-Admx {
     param (
         [string]$SourceFolder,
         [string]$TargetFolder,
@@ -896,302 +551,307 @@ function Copy-Admx
         [string[]]$Languages = $null
     )
     if (-not (Test-Path -Path "$($TargetFolder)")) { $null = (New-Item -Path "$($TargetFolder)" -ItemType Directory -Force) }
-    if (-not $Languages -or $Languages -eq "") { $Languages = @('en-US') }
+    if (-not $Languages -or $Languages -eq '') { $Languages = @('en-US') }
 
     Write-Verbose "Copying Admx files from '$($SourceFolder)' to '$($TargetFolder)'"
     Copy-Item -Path "$($SourceFolder)\*.admx" -Destination "$($TargetFolder)" -Force
-    foreach ($language in $Languages)
-    {
-        if (-not (Test-Path -Path "$($SourceFolder)\$($language)"))
-        {
+    foreach ($language in $Languages) {
+        if (-not (Test-Path -Path "$($SourceFolder)\$($language)")) {
             Write-Verbose "$($language) not found"
             if (-not $Quiet) { Write-Warning "Language '$($language)' not found for '$($ProductName)'. Processing 'en-US' instead." }
-            $language = "en-US"
+            $language = 'en-US'
         }
-        if (-not (Test-Path -Path "$($TargetFolder)\$($language)"))
-        {
+        if (-not (Test-Path -Path "$($TargetFolder)\$($language)")) {
             Write-Verbose "'$($TargetFolder)\$($language)' does not exist, creating folder"
             $null = (New-Item -Path "$($TargetFolder)\$($language)" -ItemType Directory -Force)
         }
         Write-Verbose "Copying '$($SourceFolder)\$($language)\*.adml' to '$($TargetFolder)\$($language)'"
         Copy-Item -Path "$($SourceFolder)\$($language)\*.adml" -Destination "$($TargetFolder)\$($language)" -Force
     }
-    if ($PolicyStore)
-    {
+    if ($PolicyStore) {
         Write-Verbose "Copying Admx files from '$($SourceFolder)' to '$($PolicyStore)'"
         Copy-Item -Path "$($SourceFolder)\*.admx" -Destination "$($PolicyStore)" -Force
-        foreach ($language in $Languages)
-        {
-            if (-not (Test-Path -Path "$($SourceFolder)\$($language)")) { $language = "en-US" }
+        foreach ($language in $Languages) {
+            if (-not (Test-Path -Path "$($SourceFolder)\$($language)")) { $language = 'en-US' }
             if (-not (Test-Path -Path "$($PolicyStore)$($language)")) { $null = (New-Item -Path "$($PolicyStore)$($language)" -ItemType Directory -Force) }
             Copy-Item -Path "$($SourceFolder)\$($language)\*.adml" -Destination "$($PolicyStore)$($language)" -Force
         }
     }
 }
 
-function Get-FSLogixOnline
-{
+# Get-EvergreenAdmx functions
+function Get-EvergreenAdmxFSLogix {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for FSLogix
+        Returns latest download url and version for Microsoft FSLogix policy definitions files.
     #>
 
-    try
-    {
-        # grab URI (redirected url)
+    try {
+        # Grab URI (redirected url)
         $URL = 'https://aka.ms/fslogix/download'
         $URI = (Resolve-Uri -Uri $URL).URI
-        # grab version
-        $Version = Get-Version -String $URI -Pattern "(\d+(\.\d+){1,4})"
+        # Grab version
+        $Version = Get-Version -String $URI -Pattern '(\d+(\.\d+){1,4})'
 
-        # return evergreen object
+        # Return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-MicrosoftOfficeAdmxOnline
-{
+function Get-EvergreenAdmx365Apps {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for the Office Admx files (both x64 and x86)
+        Returns latest both x86 and x64 download url and version for Microsoft 365 Apps policy definitions files.
     #>
 
-    $id = "49030"
+    $id = '49030'
     $urlVersion = "https://www.microsoft.com/en-us/download/details.aspx?id=$($id)"
-    $JSONBlobPattern = "(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)"
+    $JSONBlobPattern = '(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)'
 
-    try
-    {
+    try {
 
-        # load page for version scrape
-        $web = Invoke-WebRequest -UseDefaultCredentials -UseBasicParsing -Uri $urlVersion -MaximumRedirection 0 -UserAgent 'Googlebot/2.1 (+http://www.google.com/bot.html)'
-        # grab version
+        # Load web page for scrapping url version
+        $web = Invoke-WebRequest -UseDefaultCredentials -UseBasicParsing -Uri $urlVersion -MaximumRedirection 0
+        # Grab version
         $regEx = '(version\":")((?:\d+\.)+(?:\d+))"'
         $version = ($web.RawContent | Select-String -Pattern $regEx).Matches.Groups[2].Value
 
-        # carve JSON from script tag
-        $web = $web.Content | Select-String -Pattern $JSONBlobPattern | Select-Object -ExpandProperty Matches | ForEach-Object { $_.Groups["JSObject"].Value } | Select-Object -First 1 | ConvertFrom-JSON
-        # grab x64 version
-        $hrefx64 = $web.dlcDetailsView.downloadFile | Where-Object { $_.url -like "*x64*" } | Select-Object -First 1
-        # grab x86 version
-        $hrefx86 = $web.dlcDetailsView.downloadFile | Where-Object { $_.url -like "*x86*" } | Select-Object -First 1
+        # Carve JSON from script tag
+        $web = $web.Content | Select-String -Pattern $JSONBlobPattern | Select-Object -ExpandProperty Matches | ForEach-Object { $_.Groups['JSObject'].Value } | Select-Object -First 1 | ConvertFrom-Json
+        # Grab x64 version
+        $hrefx64 = $web.dlcDetailsView.downloadFile | Where-Object { $_.url -like '*x64*' } | Select-Object -First 1
+        # Grab x86 version
+        $hrefx86 = $web.dlcDetailsView.downloadFile | Where-Object { $_.url -like '*x86*' } | Select-Object -First 1
 
-        # return evergreen object
-        return @( @{ Version = $version; URI = $hrefx64.url; Architecture = "x64" }, @{ Version = $version; URI = $hrefx86.url; Architecture = "x86" })
-    }
-    catch
-    {
+        # Return evergreen object
+        return @( @{ Version = $version; URI = $hrefx64.url; Architecture = 'x64' }, @{ Version = $version; URI = $hrefx86.url; Architecture = 'x86' })
+    } catch {
         Throw $_
     }
 }
 
-function Get-WindowsAdmxDownloadId
-{
+function Get-WindowsDownloadId {
     <#
     .SYNOPSIS
         Returns Windows admx download Id
 
-    .PARAMETER WindowsEdition
-        Specifies Windows edition (Example: 11)
-
     .PARAMETER WindowsVersion
-        Specifies Windows version (Example: 23H2)
+        Specifies Windows major version. Supports 10, 11 or 2025. Default is 11.
+
+    .PARAMETER WindowsFeatureVersion
+        Specifies Windows client feature edition. Default is 24H2.
+
+    .EXAMPLE
+        Get-WindowsDownloadId -WindowsVersion 11 -WindowsFeatureVersion 24H2
     #>
 
     param (
         [Parameter(Position = 0, ValueFromPipeline = $true)]
-        [ValidateSet("10", "11")]
+        [ValidateSet('10', '11', '2025')]
         [ValidateNotNullOrEmpty()]
-        [int]$WindowsEdition = "11",
+        [int]$WindowsVersion = '11',
         [Parameter(Position = 1, ValueFromPipeline = $true)]
-        [ValidateSet("1903", "1909", "2004", "20H2", "21H1", "21H2", "22H2", "23H2", "24H2")]
+        [ValidateScript({
+                if ($WindowsVersion -eq '10' -and $_ -in @('1903', '1909', '2004', '20H2', '21H1', '21H2', '22H2')) {
+                    return $true
+                } elseif ($WindowsVersion -eq '11' -and $_ -in @('21H2', '22H2', '23H2', '24H2')) {
+                    return $true
+                } elseif ($WindowsVersion -eq '2025') {
+                    return $true
+                } else {
+                    throw "Invalid Windows Feature Version '$_' for Windows $WindowsVersion. Windows 10 supports: 1903, 1909, 2004, 20H2, 21H1, 21H2, 22H2. Windows 11 supports: 21H2, 22H2, 23H2, 24H2. Windows 2025 has no feature editions."
+                }
+            })]
         [ValidateNotNullOrEmpty()]
-        [string]$WindowsVersion = "24H2"
+        [string]$WindowsFeatureVersion = '24H2'
     )
 
-    switch ($WindowsEdition)
-    {
-        10
-        {
-            return (@( @{ "1903" = "58495" }, @{ "1909" = "100591" }, @{ "2004" = "101445" }, @{ "20H2" = "102157" }, @{ "21H1" = "103124" }, @{ "21H2" = "104042" }, @{ "22H2" = "104677" } ).$WindowsVersion)
+    switch ($WindowsVersion) {
+        10 {
+            return (@( @{ '1903' = '58495' }, @{ '1909' = '100591' }, @{ '2004' = '101445' }, @{ '20H2' = '102157' }, @{ '21H1' = '103124' }, @{ '21H2' = '104042' }, @{ '22H2' = '104677' } ).$WindowsFeatureVersion)
             break
         }
-        11
-        {
-            return (@( @{ "21H2" = "103507" }, @{ "22H2" = "104593" }, @{ "23H2" = "105667" }, @{ "24H2" = "106254" } ).$WindowsVersion)
+        11 {
+            return (@( @{ '21H2' = '103507' }, @{ '22H2' = '104593' }, @{ '23H2' = '105667' }, @{ '24H2' = '106254' } ).$WindowsFeatureVersion)
+            break
+        }
+        2025 {
+            return @( '106295' )
             break
         }
     }
 }
 
-function Get-WindowsAdmxOnline
-{
+function Get-EvergreenAdmxWindows {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for the Windows 10 or Windows 11 Admx files
+        Returns url and latest version for Windows 10, Windows 11 or Windows Server 2025 policy definitions files.
 
     .PARAMETER DownloadId
-        Id returned from Get-WindowsAdmxDownloadId
+        Id returned from Get-WindowsDownloadId. Default is the latest version for the current Windows major version.
     #>
 
     [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
     param(
-        [int]$DownloadId = (Get-WindowsAdmxDownloadId)
+        [int]$DownloadId = (Get-WindowsDownloadId)
     )
 
     $urlVersion = "https://www.microsoft.com/en-us/download/details.aspx?id=$($DownloadId)"
-    $JSONBlobPattern = "(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)"
+    $JSONBlobPattern = '(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)'
 
-    try
-    {
+    try {
 
-        # load page for version scrape
-        $web = Invoke-WebRequest -UseDefaultCredentials -UseBasicParsing -Uri $urlVersion -UserAgent 'Googlebot/2.1 (+http://www.google.com/bot.html)'
+        # Load web page for scrapping url version
+        $web = Invoke-WebRequest -UseDefaultCredentials -UseBasicParsing -Uri $urlVersion
 
-        # grab version
+        # Grab version
         $regEx = '(version\":")((?:\d+\.)+(?:\d+))"'
         $version = ('{0}.{1}' -f $DownloadId, ($web | Select-String -Pattern $regEx).Matches.Groups[2].Value)
 
-        # carve JSON from script tag
-        $web = $web.Content | Select-String -Pattern $JSONBlobPattern | Select-Object -ExpandProperty Matches | ForEach-Object { $_.Groups["JSObject"].Value } | Select-Object -First 1 | ConvertFrom-JSON
-        $href = $web.dlcDetailsView.downloadFile | Where-Object { $_.url -like "*.msi" } | Select-Object -First 1
+        # Carve JSON from script tag
+        $web = $web.Content | Select-String -Pattern $JSONBlobPattern | Select-Object -ExpandProperty Matches | ForEach-Object { $_.Groups['JSObject'].Value } | Select-Object -First 1 | ConvertFrom-Json
+        $href = $web.dlcDetailsView.downloadFile | Where-Object { $_.url -like '*.msi' } | Select-Object -First 1
 
-        # return evergreen object
+        # Return Evergreen object
         return @{ Version = $version; URI = $href.url }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-OneDriveOnline
-{
+function Get-EvergreenAdmxOneDrive {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for OneDrive
+        Returns url and latest version for Microsoft OneDrive policy definitions files.
     #>
 
     [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
     param (
-        [bool]$PreferLocalOneDrive
+        [switch]$PreferLocalOneDrive
     )
 
-    # detect if OneDrive is installed
-    $localOneDrive = (Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -like "*OneDrive*" }) | Sort-Object -Property Version -Descending | Select-Object -First 1
-    If (-Not $localOneDrive )
-    {
-        $localOneDrive = (Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -like "*OneDrive*" }) | Sort-Object -Property Version -Descending | Select-Object -First 1
-    }
-    If (-Not $localOneDrive )
-    {
-        $localOneDrive = (Get-ItemProperty HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -like "*OneDrive*" }) | Sort-Object -Property Version -Descending | Select-Object -First 1
-    }
+    try {
+        # Detect if OneDrive is installed
+        if (Get-Variable -Name isOneDriveInstalled -ErrorAction SilentlyContinue) {
+            Clear-Variable -Name isOneDriveInstalled -Force
+        }
+        $UserInstall = (Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' | Where-Object { $_.DisplayName -like '*OneDrive*' }) | Sort-Object -Property DisplayVersion -Descending | Select-Object -First 1
+        $Systemx64Install = (Get-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' | Where-Object { $_.DisplayName -like '*OneDrive*' }) | Sort-Object -Property DisplayVersion -Descending | Select-Object -First 1
+        $Systemx86Install = (Get-ItemProperty -Path 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' | Where-Object { $_.DisplayName -like '*OneDrive*' }) | Sort-Object -Property DisplayVersion -Descending | Select-Object -First 1
+        $url = 'https://evergreen-api.stealthpuppy.com/app/MicrosoftOneDrive'
+        $architecture = 'x64'
+        $ring = 'Insider'
+        $type = 'exe'
+        $Evergreen = Invoke-RestMethod -Uri $url
+        $Evergreen = $Evergreen | Where-Object { $_.Architecture -eq $architecture -and $_.Ring -eq $ring -and $_.Type -eq $type } | `
+                Sort-Object -Property @{ Expression = { [System.Version]$_.Version }; Descending = $true } | Select-Object -First 1
 
+        If (-not [string]::IsNullOrWhiteSpace($UserInstall)) {
+            Write-Verbose "User OneDrive install found: $($UserInstall.DisplayVersion)"
+            $isOneDriveInstalled = $true
+            $OneDriveInstalledVersion = $UserInstall.DisplayVersion
+            $global:oneDriveADMXFolder = (Get-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\OneDrive').CurrentVersionPath
+        }
+        If (-not [string]::IsNullOrWhiteSpace($Systemx64Install)) {
+            Write-Verbose "System x64 OneDrive install found: $($Systemx64Install.DisplayVersion)"
+            $isOneDriveInstalled = $true
+            $OneDriveInstalledVersion = $Systemx64Install.DisplayVersion
+            $global:oneDriveADMXFolder = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\OneDrive').CurrentVersionPath
+        }
+        If (-not [string]::IsNullOrWhiteSpace($Systemx86Install)) {
+            Write-Verbose "System x86 OneDrive install found: $($Systemx86Install.DisplayVersion )"
+            $isOneDriveInstalled = $true
+            $OneDriveInstalledVersion = $Systemx86Install.DisplayVersion
+            $global:oneDriveADMXFolder = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\OneDrive').CurrentVersionPath
+        }
 
-    if (($PreferLocalOneDrive) -and [bool]($localOneDrive))
-    {
-        $URI = "$((Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\OneDrive").CurrentVersionPath)"
-        $Version = $localOneDrive.DisplayVersion
-        return @{ Version = $Version; URI = $URI }
-    }
-    elseIf (-Not $PreferLocalOneDrive)
-    {
-        try
-        {
-            $url = "https://evergreen-api.stealthpuppy.com/app/MicrosoftOneDrive"
-            $architecture = "AMD64"
-            $ring = "Insider"
-            $type = "exe"
-            $Evergreen = Invoke-RestMethod -Uri $url
-            $Evergreen = $Evergreen | Where-Object { $_.Architecture -eq $architecture -and $_.Ring -eq $ring -and $_.Type -eq $type } | `
-                    Sort-Object -Property @{ Expression = { [System.Version]$_.Version }; Descending = $true } | Select-Object -First 1
+        if ($PreferLocalOneDrive) {
+            If ($isOneDriveInstalled) {
+                return @{ Version = $OneDriveInstalledVersion }
+            } else {
+                Write-Warning 'No local installation of Microsoft OneDrive install found.'
+                # Grab download uri
+                $URI = $Evergreen.URI
 
-            # grab download uri
+                # Grab version
+                $Version = $Evergreen.Version
+
+                # Return evergreen object
+                return @{ Version = $Version; URI = $URI }
+            }
+        } else {
+            # Grab download uri
             $URI = $Evergreen.URI
 
-            # grab version
+            # Grab version
             $Version = $Evergreen.Version
 
-            # return evergreen object
+            # Return evergreen object
             return @{ Version = $Version; URI = $URI }
         }
-        catch
-        {
-            Throw $_
-        }
+    } catch {
+        Throw $_
     }
 }
 
-function Get-MicrosoftEdgePolicyOnline
-{
+function Get-EvergreenAdmxEdge {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for the Microsoft Edge Admx files
+        Returns url and latest version for Microsoft Edge policy definitions files.
     #>
 
-    try
-    {
+    try {
 
-        $url = "https://edgeupdates.microsoft.com/api/products?view=enterprise"
-        # grab json containing product info
+        $url = 'https://edgeupdates.microsoft.com/api/products?view=enterprise'
+        # Grab json containing product info
         $json = Invoke-WebRequest -UseDefaultCredentials -Uri $url -UseBasicParsing -MaximumRedirection 0 | ConvertFrom-Json
-        # filter out the newest release
-        $release = ($json | Where-Object { $_.Product -like "Policy" }).Releases | Sort-Object ProductVersion -Descending | Select-Object -First 1
-        # grab version
+        # Filter out the newest release
+        $release = ($json | Where-Object { $_.Product -like 'Policy' }).Releases | Sort-Object ProductVersion -Descending | Select-Object -First 1
+        # Grab version
         $Version = $release.ProductVersion
-        # grab uri
+        # Grab uri
         $URI = $release.Artifacts[0].Location
 
-        # return evergreen object
+        # Return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 
 }
 
-function Get-GoogleChromeAdmxOnline
-{
+function Get-EvergreenAdmxChrome {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for the Google Chrome Admx files
+        Returns url and latest version for Google Chrome policy definitions files.
     #>
 
-    try
-    {
+    try {
 
-        $URI = "https://dl.google.com/dl/edgedl/chrome/policy/policy_templates.zip"
-        # download the file
-        Invoke-WebRequest -UseDefaultCredentials -Uri $URI -OutFile "$($env:TEMP)\policy_templates.zip"
-        # extract the file
-        Expand-Archive -Path "$($env:TEMP)\policy_templates.zip" -DestinationPath "$($env:TEMP)\chromeadmx" -Force
+        $DownloadUrl = 'https://dl.google.com/dl/edgedl/chrome/policy/policy_templates.zip'
 
-        # open the version file
-        $versionfile = (Get-Content -Path "$($env:TEMP)\chromeadmx\VERSION").Split('=')
-        $Version = "$($versionfile[1]).$($versionfile[3]).$($versionfile[5]).$($versionfile[7])"
+        $url = 'https://evergreen-api.stealthpuppy.com/app/GoogleChrome'
+        $channel = 'Stable'
+        $architecture = 'x64'
+        $type = 'msi'
+        $Evergreen = Invoke-RestMethod -Uri $url
+        $Evergreen = $Evergreen | Where-Object { $_.Channel -eq $channel -and $_.Architecture -eq $architecture -and $_.Type -eq $type } | `
+                Sort-Object -Property @{ Expression = { [System.Version]$_.Version }; Descending = $true } | Select-Object -First 1
 
-        # cleanup
-        Remove-Item -Path "$($env:TEMP)\policy_templates.zip" -Force
-        Remove-Item -Path "$($env:TEMP)\chromeadmx" -Recurse -Force
+        $Version = $Evergreen.Version
 
-        # return evergreen object
-        return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+        # Return evergreen object
+        return @{ Version = $Version; URI = $DownloadUrl }
+    } catch {
         Throw $_
     }
 }
 
-function Get-AdobeAcrobatAdmxOnline
-{
+function Get-EvergreenAdmxAdobeAcrobat {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for the Adobe Acrobat Continuous track Admx files. Use this for Acrobat , 64-bit Reader, and the unified installer.
@@ -1202,47 +862,39 @@ function Get-AdobeAcrobatAdmxOnline
 
     param (
         [Parameter()]
-        [ValidateSet("Continuous", "Classic2020", "Classic2017")]
+        [ValidateSet('Continuous', 'Classic2020', 'Classic2017')]
         [ValidateNotNullOrEmpty()]
-        [string]$Track = "Continuous"
+        [string]$Track = 'Continuous'
     )
 
-    switch ($Track)
-    {
-        Continuous
-        {
-            $URL = "https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/misc/AcrobatADMTemplate.zip"
+    switch ($Track) {
+        Continuous {
+            $URL = 'https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/misc/AcrobatADMTemplate.zip'
         }
-        Classic2020
-        {
-            $URL = "https://ardownload2.adobe.com/pub/adobe/acrobat/win/Acrobat2020/misc/AcrobatADMTemplate.zip"
+        Classic2020 {
+            $URL = 'https://ardownload2.adobe.com/pub/adobe/acrobat/win/Acrobat2020/misc/AcrobatADMTemplate.zip'
         }
-        Classic2017
-        {
-            $URL = "https://ardownload2.adobe.com/pub/adobe/acrobat/win/Acrobat2017/misc/AcrobatADMTemplate.zip"
+        Classic2017 {
+            $URL = 'https://ardownload2.adobe.com/pub/adobe/acrobat/win/Acrobat2017/misc/AcrobatADMTemplate.zip'
         }
     }
 
-    try
-    {
+    try {
         # grab uri
         $URI = (Resolve-Uri -Uri $URL).URI
 
         # grab version
         $LastModifiedDate = (Resolve-Uri -Uri $URL).LastModified
-        [version]$Version = $LastModifiedDate.ToString("yyyy.MM.dd")
+        [version]$Version = $LastModifiedDate.ToString('yyyy.MM.dd')
 
         # return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-AdobeReaderAdmxOnline
-{
+function Get-EvergreenAdmxAdobeReader {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for the Adobe Reader admx files
@@ -1253,194 +905,189 @@ function Get-AdobeReaderAdmxOnline
 
     param (
         [Parameter()]
-        [ValidateSet("Continuous", "Classic2020", "Classic2017")]
+        [ValidateSet('Continuous', 'Classic2020', 'Classic2017')]
         [ValidateNotNullOrEmpty()]
-        [string]$Track = "Continuous"
+        [string]$Track = 'Continuous'
     )
 
-    switch ($Track)
-    {
-        Continuous
-        {
-            $URL = "https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/misc/ReaderADMTemplate.zip"
+    switch ($Track) {
+        Continuous {
+            $URL = 'https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/misc/ReaderADMTemplate.zip'
         }
-        Classic2020
-        {
-            $URL = "https://ardownload2.adobe.com/pub/adobe/reader/win/Acrobat2020/misc/ReaderADMTemplate.zip"
+        Classic2020 {
+            $URL = 'https://ardownload2.adobe.com/pub/adobe/reader/win/Acrobat2020/misc/ReaderADMTemplate.zip'
         }
-        Classic2017
-        {
-            $URL = "https://ardownload2.adobe.com/pub/adobe/reader/win/Acrobat2017/misc/ReaderADMTemplate.zip"
+        Classic2017 {
+            $URL = 'https://ardownload2.adobe.com/pub/adobe/reader/win/Acrobat2017/misc/ReaderADMTemplate.zip'
         }
     }
 
-    try
-    {
+    try {
         # grab uri
         $URI = (Resolve-Uri -Uri $URL).URI
 
         # grab version
         $LastModifiedDate = (Resolve-Uri -Uri $URL).LastModified
-        [version]$Version = $LastModifiedDate.ToString("yyyy.MM.dd")
+        [version]$Version = $LastModifiedDate.ToString('yyyy.MM.dd')
 
         # return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-CitrixWorkspaceAppAdmxOnline
-{
+function Get-EvergreenAdmxWorkplaceApp {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for Citrix Workspace App ADMX files
     #>
 
-    try
-    {
+    try {
 
-        $url = "https://www.citrix.com/downloads/workspace-app/windows/workspace-app-for-windows-latest.html"
+        $url = 'https://www.citrix.com/downloads/workspace-app/windows/workspace-app-for-windows-latest.html'
         # grab content
         $web = (Invoke-WebRequest -UseDefaultCredentials -Uri $url -UseBasicParsing -DisableKeepAlive).RawContent
         # find line with ADMX download
-        $str = ($web -split "`r`n" | Select-String -Pattern "_ADMX_")[0].ToString().Trim()
+        $str = ($web -split "`r`n" | Select-String -Pattern '_ADMX_')[0].ToString().Trim()
         # extract url from ADMX download string
         $URI = "https:$(((Select-String '(\/\/)([^\s,]+)(?=")' -Input $str).Matches.Value))"
         # grab version
-        $VersionRegEx = "Version\: ((?:\d+\.)+(?:\d+)) \((.+)\)"
+        $VersionRegEx = 'Version\: ((?:\d+\.)+(?:\d+)) \((.+)\)'
         $Version = ($web | Select-String -Pattern $VersionRegEx).Matches.Groups[1].Value
 
         # return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-MozillaFirefoxAdmxOnline
-{
+function Get-EvergreenAdmxFirefox {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for Mozilla Firefox ADMX files
     #>
 
-    try
-    {
+    try {
 
         # define github repo
-        $repo = "mozilla/policy-templates"
+        $repo = 'mozilla/policy-templates'
         # grab latest release properties
         $latest = (Invoke-WebRequest -UseDefaultCredentials -Uri "https://api.github.com/repos/$($repo)/releases" -UseBasicParsing | ConvertFrom-Json)[0]
 
         # grab version
-        $Version = ($latest.tag_name | Select-String -Pattern "(\d+(\.\d+){1,4})" -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
+        $Version = ($latest.tag_name | Select-String -Pattern '(\d+(\.\d+){1,4})' -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
         # grab uri
         $URI = $latest.assets.browser_download_url
 
         # return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-BIS-FAdmxOnline
-{
+function Get-EvergreenAdmxBISF {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for BIS-F ADMX files
     #>
 
-    try
-    {
+    try {
 
         # define github repo
-        $repo = "EUCweb/BIS-F"
+        $repo = 'EUCweb/BIS-F'
         # grab latest release properties
         $latest = (Invoke-WebRequest -UseDefaultCredentials -Uri "https://api.github.com/repos/$($repo)/releases" -UseBasicParsing | ConvertFrom-Json)[0]
 
         # grab version
-        $Version = ($latest.tag_name | Select-String -Pattern "(\d+(\.\d+){1,4})" -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
+        $Version = ($latest.tag_name | Select-String -Pattern '(\d+(\.\d+){1,4})' -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
         # grab uri
         $URI = $latest.zipball_url
 
         # return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-MDOPAdmxOnline
-{
+function Get-EvergreenAdmxMDOP {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for the Desktop Optimization Pack Admx files (both x64 and x86)
     #>
 
-    $id = "55531"
+    $id = '55531'
     $urlversion = "https://www.microsoft.com/en-us/download/details.aspx?id=$($id)"
-    $JSONBlobPattern = "(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)"
-    try
-    {
-        # load page for version scrape
+    $JSONBlobPattern = '(?<scriptStart><script>[\w.]+__DLCDetails__=).*?(?<JSObject-scriptStart></script>)'
+    try {
+        # Load web page for scrapping admx version
         $web = Invoke-WebRequest -UseDefaultCredentials -UseBasicParsing -Uri $urlversion
         # grab version
         $regEx = '(version\":")((?:\d+\.)+(?:\d+))"'
         $version = ($web | Select-String -Pattern $regEx).Matches.Groups[2].Value
 
         # carve JSON from script tag
-        $web = $web.Content | Select-String -Pattern $JSONBlobPattern | Select-Object -ExpandProperty Matches | ForEach-Object { $_.Groups["JSObject"].Value } | Select-Object -First 1 | ConvertFrom-JSON
+        $web = $web.Content | Select-String -Pattern $JSONBlobPattern | Select-Object -ExpandProperty Matches | ForEach-Object { $_.Groups['JSObject'].Value } | Select-Object -First 1 | ConvertFrom-Json
         # grab download url
         $href = $web.dlcDetailsView.downloadFile
 
         # return evergreen object
         return @{ Version = $Version; URI = $href.url }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-ZoomDesktopClientAdmxOnline
-{
+function Get-EvergreenAdmxZoom {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for Zoom Desktop Client ADMX files
+        Returns latest Version and Uri for Zoom ADMX files
     #>
 
-    try
-    {
-        $url = "https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0065466"
+    try {
+        $url = 'https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0065466'
 
         # grab content
         $web = Invoke-WebRequest -UseDefaultCredentials -Uri $url -UseBasicParsing -UserAgent 'Googlebot/2.1 (+http://www.google.com/bot.html)'
         # find ADMX download
-        $URI = (($web.Links | Where-Object { $_.href -like "*msi-templates*.zip" })[-1]).href
+        $URI = (($web.Links | Where-Object { $_.href -like '*msi-templates*.zip' })[-1]).href
         # grab version
-        $Version = ($URI.Split("/")[-1] | Select-String -Pattern "(\d+(\.\d+){1,4})" -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
+        $Version = ($URI.Split('/')[-1] | Select-String -Pattern '(\d+(\.\d+){1,4})' -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
 
         # return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-CustomPolicyOnline
-{
+function Get-EvergreenAdmxZoomVDI {
+    <#
+    .SYNOPSIS
+        Returns latest Version and Uri for Zoom VDI ADMX files
+    #>
+
+    try {
+        $url = 'https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064784'
+
+        # grab content
+        $web = Invoke-WebRequest -UseDefaultCredentials -Uri $url -UseBasicParsing -UserAgent 'Googlebot/2.1 (+http://www.google.com/bot.html)'
+        # find ADMX download
+        $URI = (($web.Links | Where-Object { $_.href -like '*msi-templates*.zip' })[-1]).href
+        # grab version
+        $Version = ($URI.Split('/')[-1] | Select-String -Pattern '(\d+(\.\d+){1,4})' -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
+
+        # return evergreen object
+        return @{ Version = $Version; URI = $URI }
+    } catch {
+        Throw $_
+    }
+}
+
+function Get-CustomPolicyOnline {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for Custom Policies
@@ -1450,227 +1097,131 @@ function Get-CustomPolicyOnline
     #>
 
     param(
-        [string] $CustomPolicyStore
+        [string] $AddAdmxPath
     )
 
-    $newestFileDate = Get-Date -Date ((Get-ChildItem -Path $CustomPolicyStore -Include "*.admx", "*.adml" -Recurse | Sort-Object LastWriteTime -Descending) | Select-Object -First 1).LastWriteTime
+    $newestFileDate = Get-Date -Date ((Get-ChildItem -Path $AddAdmxPath -Include '*.admx', '*.adml' -Recurse | Sort-Object LastWriteTime -Descending) | Select-Object -First 1).LastWriteTime
 
-    $version = Get-Date -Date $newestFileDate -Format "yyMM.dd.HHmmss"
+    $version = Get-Date -Date $newestFileDate -Format 'yyMM.dd.HHmmss'
 
-    return @{ Version = $version; URI = $CustomPolicyStore }
+    return @{ Version = $version; URI = $AddAdmxPath }
 }
 
-function Get-AzureVirtualDesktopAdmxOnline
-{
+function Get-EvergreenAdmxAVD {
     <#
     .SYNOPSIS
-        Returns latest Version and Uri for Azure Virtual Desktop ADMX files
+        Returns latest url and version for MicrosoftMicrosoft AVD policy definition files.
     #>
 
-    try
-    {
-        $URL = "https://aka.ms/avdgpo"
+    try {
+        $URL = 'https://aka.ms/avdgpo'
 
-        # grab uri
+        # Grab uri
         $URI = (Resolve-Uri -Uri $URL).URI
 
-        # grab version
+        # Grab version
         $LastModifiedDate = (Resolve-Uri -Uri $URL).LastModified
-        [version]$Version = $LastModifiedDate.ToString("yyyy.MM.dd")
+        [version]$Version = $LastModifiedDate.ToString('yyyy.MM.dd')
 
-        # return evergreen object
+        # Return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-WingetAdmxOnline
-{
+function Get-EvergreenAdmxWinget {
     <#
     .SYNOPSIS
         Returns latest Version and Uri for Winget-cli ADMX files
     #>
 
-    try
-    {
+    try {
 
-        # define github repo
-        $repo = "microsoft/winget-cli"
-        # grab latest release properties
+        # Define github repo
+        $repo = 'microsoft/winget-cli'
+        # Grab latest release properties
         $latest = ((Invoke-WebRequest -UseDefaultCredentials -Uri "https://api.github.com/repos/$($repo)/releases" -UseBasicParsing | ConvertFrom-Json) | Where-Object { $_.name -notlike '*-preview' -and $_.draft -eq $false -and $_.assets.browser_download_url -match 'DesktopAppInstallerPolicies.zip' })[0]
 
-        # grab version
-        $Version = ($latest.tag_name | Select-String -Pattern "(\d+(\.\d+){1,4})" -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
-        # grab uri
-        $URI = $latest.assets.browser_download_url | Where-Object { $_ -like '*/DesktopAppInstallerPolicies.zip'}
+        # Grab version
+        $Version = ($latest.tag_name | Select-String -Pattern '(\d+(\.\d+){1,4})' -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
+        # Grab uri
+        $URI = $latest.assets.browser_download_url | Where-Object { $_ -like '*/DesktopAppInstallerPolicies.zip' }
 
-        # return evergreen object
+        # Return evergreen object
         return @{ Version = $Version; URI = $URI }
-    }
-    catch
-    {
+    } catch {
         Throw $_
     }
 }
 
-function Get-FSLogixAdmx
-{
+function Get-EvergreenAdmxBrave {
     <#
     .SYNOPSIS
-        Process FSLogix Admx files
-
-    .PARAMETER Version
-        Current Version present
-
-    .PARAMETER PolicyStore
-        Destination for the Admx files
+        Returns latest Version and Uri for Brave ADMX files
     #>
 
-    param(
-        [string]$Version,
-        [string]$PolicyStore = $null,
-        [string[]]$Languages = $null
-    )
+    try {
 
-    $Evergreen = Get-FSLogixOnline
-    $ProductName = "FSLogix"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+        # define github repo
+        $repo = 'brave/brave-browser'
+        # grab latest release properties
+        $latest = ((Invoke-WebRequest -UseDefaultCredentials -Uri "https://api.github.com/repos/$($repo)/releases/latest" -UseBasicParsing | ConvertFrom-Json) | Where-Object { $_.assets.browser_download_url -match 'policy_templates.zip' })[0]
 
-    # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
-        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+        # grab version
+        $Version = ($latest.tag_name | Select-String -Pattern '(\d+(\.\d+){1,4})' -AllMatches | ForEach-Object { $_.Matches } | ForEach-Object { $_.Value }).ToString()
+        # grab uri
+        $URI = $latest.assets.browser_download_url | Where-Object { $_ -like '*/policy_templates.zip' }
 
-        # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
-            # download
-            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
-            Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
-
-            # extract
-            Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\$($ProductName)'"
-            Expand-Archive -Path $OutFile -DestinationPath "$($env:TEMP)\$($ProductName)" -Force
-
-            # copy
-            $SourceAdmx = "$($env:TEMP)\$($ProductName)"
-            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            if (-not (Test-Path -Path "$($TargetAdmx)\en-US")) { $null = (New-Item -Path "$($TargetAdmx)\en-US" -ItemType Directory -Force) }
-
-            Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($TargetAdmx)'"
-            Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($TargetAdmx)" -Force
-            Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($TargetAdmx)\en-US" -Force
-            if ($PolicyStore)
-            {
-                Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($PolicyStore)'"
-                Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($PolicyStore)" -Force
-                if (-not (Test-Path -Path "$($PolicyStore)en-US")) { $null = (New-Item -Path "$($PolicyStore)en-US" -ItemType Directory -Force) }
-                Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($PolicyStore)en-US" -Force
-            }
-
-            # cleanup
-            Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
-
-            return $Evergreen
-        }
-        catch
-        {
-            Throw $_
-        }
-    }
-    else
-    {
-        # version already processed
-        return $null
+        # return evergreen object
+        return @{ Version = $Version; URI = $URI }
+    } catch {
+        Throw $_
     }
 }
 
-function Get-MicrosoftOfficeAdmx
-{
+function Get-EvergreenAdmxSlack {
     <#
     .SYNOPSIS
-        Process Office Admx files
-
-    .PARAMETER Version
-        Current Version present
-
-    .PARAMETER PolicyStore
-        Destination for the Admx files
-
-    .PARAMETER Architecture
-        Architecture (x86 or x64)
+        Returns url and latest Slack policy definition files.
     #>
 
-    param(
-        [string]$Version,
-        [string]$PolicyStore = $null,
-        [string]$Architecture = "x64",
-        [string[]]$Languages = $null
-    )
+    try {
+        $url = 'https://slack.com/help/articles/11906214948755-Manage-desktop-app-configurations'
 
-    $Evergreen = Get-MicrosoftOfficeAdmxOnline | Where-Object { $_.Architecture -like $Architecture }
-    $ProductName = "Microsoft Office $($Architecture)"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+        # grab content
+        $web = (Invoke-WebRequest -UseDefaultCredentials -Uri $url -UseBasicParsing -DisableKeepAlive).RawContent
+        # find line with ADMX download
+        $str = ($web -split "`r`n")
+        # extract url from ADMX download string
+        $regEx = '(https\:\/\/[^\s,]+(?=))(\"\>Group Policy Object template)'
+        $URI = (Select-String -Pattern $regEx -Input $str).Matches.Groups[1].Value
 
-    # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
-        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+        # grab version
 
-        # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
-            # download
-            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
-            Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
-
-            # extract
-            Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\office'"
-            $null = Start-Process -FilePath $OutFile -ArgumentList "/quiet /norestart /extract:`"$($env:TEMP)\office`"" -PassThru -Wait
-
-            # copy
-            $SourceAdmx = "$($env:TEMP)\office\admx"
-            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
-
-            # cleanup
-            Remove-Item -Path "$($env:TEMP)\office" -Recurse -Force
-
-            return $Evergreen
-        }
-        catch
-        {
-            Throw $_
-        }
-    }
-    else
-    {
-        # version already processed
-        return $null
+        # return evergreen object
+        return @{ Version = $Version; URI = $URI }
+    } catch {
+        Throw $_
     }
 }
 
-function Get-WindowsAdmx
-{
+# Download functions
+function Invoke-EvergreenAdmxWindows {
     <#
     .SYNOPSIS
-        Process Windows 10 or Windows 11 Admx files
+        Download Windows Admx policy definitions files
 
     .PARAMETER Version
         Current Version present
 
     .PARAMETER PolicyStore
         Destination for the Admx files
+
+    .PARAMETER WindowsFeatureVersion
+        Official WindowsFeatureVersion format
 
     .PARAMETER WindowsVersion
-        Official WindowsVersion format
-
-    .PARAMETER WindowsEdition
         Differentiate between Windows 10 and Windows 11
 
     .PARAMETER Languages
@@ -1680,36 +1231,39 @@ function Get-WindowsAdmx
     param(
         [string]$Version,
         [string]$PolicyStore = $null,
-        [string]$WindowsVersion,
-        [int]$WindowsEdition,
+        [string]$WindowsFeatureVersion,
+        [int]$WindowsVersion,
         [string[]]$Languages = $null
     )
 
-    $id = Get-WindowsAdmxDownloadId -WindowsVersion $WindowsVersion -WindowsEdition $WindowsEdition
-    $Evergreen = Get-WindowsAdmxOnline -DownloadId $id
-    $ProductName = "Microsoft Windows $($WindowsEdition) $($WindowsVersion)"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    if ($WindowsVersion -eq '2025') {
+        $id = Get-WindowsDownloadId -WindowsVersion $WindowsVersion
+        $ProductName = "Microsoft Windows $($WindowsVersion)"
+    } elseif ($WindowsVersion -eq 11 -or $WindowsVersion -eq 10) {
+        $id = Get-WindowsDownloadId -WindowsVersion $WindowsVersion -WindowsFeatureVersion $WindowsFeatureVersion
+        $ProductName = "Microsoft Windows $($WindowsVersion) $($WindowsFeatureVersion)"
+    }
+    $Evergreen = Get-EvergreenAdmxWindows -DownloadId $id
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
     $TempFolder = "$($env:TEMP)\$($ProductName)"
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
 
             # install
-            Write-Verbose "Installing downloaded Windows $($WindowsEdition) Admx installer"
-            $null = Start-Process -FilePath "MsiExec.exe" -WorkingDirectory "$($WorkingDirectory)\downloads" -ArgumentList "/qn /norestart /a `"$($OutFile.split('\')[-1])`" TargetDir=`"$($TempFolder)`"" -PassThru -Wait
+            Write-Verbose "Installing downloaded Windows $($WindowsVersion) Admx installer"
+            $null = Start-Process -FilePath 'MsiExec.exe' -WorkingDirectory "$($WorkingDirectory)\downloads" -ArgumentList "/qn /norestart /a `"$($OutFile.split('\')[-1])`" TargetDir=`"$($TempFolder)`"" -PassThru -Wait
 
             # find installation path
-            Write-Verbose "Grabbing installation path for Windows $($WindowsEdition) Admx installer"
+            Write-Verbose "Grabbing installation path for Windows $($WindowsVersion) Admx installer"
             $InstallFolder = Get-ChildItem -Path "$($TempFolder)\Microsoft Group Policy"
             Write-Verbose "Found '$($InstallFolder.Name)'"
 
@@ -1722,169 +1276,16 @@ function Get-WindowsAdmx
             Remove-Item -Path $TempFolder -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-OneDriveAdmx
-{
-    <#
-    .SYNOPSIS
-        Process OneDrive Admx files
-
-    .PARAMETER Version
-        Current Version present
-
-    .PARAMETER PolicyStore
-        Destination for the Admx files
-
-    .PARAMETER PreferLocalOneDrive
-        Check locally only
-    #>
-
-    [CmdletBinding()]
-    param(
-        [string] $Version,
-        [string] $PolicyStore = $null,
-        [bool] $PreferLocalOneDrive,
-        [string[]]$Languages = $null
-    )
-
-    if ($PreferLocalOneDrive)
-    {
-        $Evergreen = Get-OneDriveOnline -PreferLocalOneDrive $PreferLocalOneDrive
-    }
-    else
-    {
-        $Evergreen = Get-OneDriveOnline
-    }
-
-    $ProductName = "Microsoft OneDrive"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
-
-    # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
-        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
-
-        # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
-            if (-not $PreferLocalOneDrive)
-            {
-                # download
-                Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
-                Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
-
-                # install
-                Write-Verbose "Installing downloaded OneDrive installer"
-                $null = Start-Process -FilePath $OutFile -ArgumentList "/allusers /silent" -PassThru
-                # wait for setup to complete
-                while (Get-Process -Name "OneDriveSetup") { Start-Sleep -Seconds 10 }
-                # onedrive starts automatically after setup. kill!
-                Stop-Process -Name "OneDrive" -Force
-
-                # find uninstall info
-                Write-Verbose "Grabbing uninstallation info from registry for OneDrive installer"
-                $uninstall = Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\OneDriveSetup.exe"
-                if ($null -eq $uninstall)
-                {
-                    $uninstall = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\OneDriveSetup.exe"
-                }
-                if ($null -eq $uninstall)
-                {
-                    Write-Warning -Message "Unable to find uninstall information for OneDrive."
-                }
-                else
-                {
-                    Write-Verbose "Found '$($uninstall.DisplayName)'"
-
-                    # find installation path
-                    Write-Verbose "Grabbing installation path for OneDrive installer"
-                    $installfolder = $uninstall.DisplayIcon.Substring(0, $uninstall.DisplayIcon.IndexOf("\OneDriveSetup.exe"))
-                    Write-Verbose "Found '$($installfolder)'"
-                }
-            }
-            else
-            {
-                $installfolder = $Evergreen.URI
-            }
-            # copy
-            $SourceAdmx = "$($installfolder)\adm"
-            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            if (-not (Test-Path -Path "$($TargetAdmx)")) { $null = (New-Item -Path "$($TargetAdmx)" -ItemType Directory -Force) }
-
-            Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($TargetAdmx)'"
-            Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($TargetAdmx)" -Force
-            foreach ($language in $Languages)
-            {
-                if (-not (Test-Path -Path "$($SourceAdmx)\$($language)") -and -not (Test-Path -Path "$($SourceAdmx)\$($language.Substring(0,2))"))
-                {
-                    if ($language -notlike "en-us") { Write-Warning "Language '$($language)' not found for '$($ProductName)'. Processing 'en-US' instead." }
-                    if (-not (Test-Path -Path "$($TargetAdmx)\en-US")) { $null = (New-Item -Path "$($TargetAdmx)\en-US" -ItemType Directory -Force) }
-                    Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($TargetAdmx)\en-US" -Force
-                }
-                else
-                {
-                    $sourcelanguage = $language; if (-not (Test-Path -Path "$($SourceAdmx)\$($language)")) { $sourcelanguage = $language.Substring(0, 2) }
-                    if (-not (Test-Path -Path "$($TargetAdmx)\$($language)")) { $null = (New-Item -Path "$($TargetAdmx)\$($language)" -ItemType Directory -Force) }
-                    Copy-Item -Path "$($SourceAdmx)\$($sourcelanguage)\*.adml" -Destination "$($TargetAdmx)\$($language)" -Force
-                }
-            }
-
-            if ($PolicyStore)
-            {
-                Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($PolicyStore)'"
-                Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($PolicyStore)" -Force
-                foreach ($language in $Languages)
-                {
-                    if (-not (Test-Path -Path "$($SourceAdmx)\$($language)") -and -not (Test-Path -Path "$($SourceAdmx)\$($language.Substring(0,2))"))
-                    {
-                        if (-not (Test-Path -Path "$($PolicyStore)en-US")) { $null = (New-Item -Path "$($PolicyStore)en-US" -ItemType Directory -Force) }
-                        Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($PolicyStore)en-US" -Force
-                    }
-                    else
-                    {
-                        $sourcelanguage = $language; if (-not (Test-Path -Path "$($SourceAdmx)\$($language)")) { $sourcelanguage = $language.Substring(0, 2) }
-                        if (-not (Test-Path -Path "$($PolicyStore)$($language)")) { $null = (New-Item -Path "$($PolicyStore)$($language)" -ItemType Directory -Force) }
-                        Copy-Item -Path "$($SourceAdmx)\$($sourcelanguage)\*.adml" -Destination "$($PolicyStore)$($language)" -Force
-                    }
-                }
-            }
-
-            if (-not $PreferLocalOneDrive)
-            {
-                # uninstall
-                Write-Verbose "Uninstalling OneDrive installer"
-                $null = Start-Process -FilePath "$($installfolder)\OneDriveSetup.exe" -ArgumentList "/uninstall /allusers" -PassThru -Wait
-            }
-
-            return $Evergreen
-        }
-        catch
-        {
-            Throw $_
-        }
-    }
-    else
-    {
-        # version already processed
-        return $null
-    }
-}
-
-function Get-MicrosoftEdgeAdmx
-{
+function Invoke-EvergreenAdmxEdge {
     <#
     .SYNOPSIS
         Process Microsoft Edge Admx files
@@ -1902,21 +1303,19 @@ function Get-MicrosoftEdgeAdmx
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-MicrosoftEdgePolicyOnline
-    $ProductName = "Microsoft Edge"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxEdge
+    $ProductName = 'Microsoft Edge'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
         $OutFile = "$($WorkingDirectory)\downloads\$($ProductName).cab"
         $ZipFile = "$($WorkingDirectory)\downloads\MicrosoftEdgePolicyTemplates.zip"
 
-        try
-        {
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -1937,27 +1336,280 @@ function Get-MicrosoftEdgeAdmx
             Remove-Item -Path "$env:TEMP\$($ProductName)" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-GoogleChromeAdmx
-{
+function Invoke-EvergreenAdmxOneDrive {
     <#
     .SYNOPSIS
-        Process Google Chrome Admx files
+        Process OneDrive Admx files
 
     .PARAMETER Version
         Current Version present
+
+    .PARAMETER PolicyStore
+        Destination for the Admx files
+
+    .PARAMETER PreferLocalOneDrive
+        Prefer policy definitions from installed local version of MicrosoftOneDrive. If not specified, Microsoft OneDrive will be installed to extract the policy definitions.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [switch]$PreferLocalOneDrive,
+        [string[]]$Languages = $null
+    )
+
+    if ($PreferLocalOneDrive) {
+        $Evergreen = Get-EvergreenAdmxOneDrive -PreferLocalOneDrive
+    } else {
+        $Evergreen = Get-EvergreenAdmxOneDrive
+    }
+
+    $ProductName = 'Microsoft OneDrive'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    # see if this is a newer version
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        try {
+            if (-not $PreferLocalOneDrive) {
+
+                # Set the output file
+                $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+
+                # Download
+                Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+                Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
+
+                # Install
+                Write-Verbose 'Installing downloaded OneDrive installer'
+                $null = Start-Process -FilePath $OutFile -ArgumentList '/allusers /silent' -PassThru
+                # Wait for setup to complete
+                while (Get-Process -Name 'OneDriveSetup' -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 10 }
+                # OneDrive starts automatically after setup. kill!
+                # Check if OneDrive is running and close it if it is
+                Write-Verbose 'Checking if OneDrive is running and stopping it if necessary'
+                $process = Get-Process -Name 'OneDrive' -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Verbose 'OneDrive process is running. Stopping it...'
+                    try {
+                        $process | Stop-Process -Force
+                        Write-Verbose 'OneDrive process stopped successfully'
+                    } catch {
+                        Write-Warning "Failed to stop OneDrive process: $_"
+                    }
+                } else {
+                    Write-Verbose 'No OneDrive process found running'
+                }
+
+                # Find uninstall info
+                Write-Verbose 'Grabbing uninstallation info from registry for OneDrive installer'
+                $uninstall = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\OneDriveSetup.exe'
+                if ($null -eq $uninstall) {
+                    $uninstall = Get-ItemProperty -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\OneDriveSetup.exe'
+                }
+                if ($null -eq $uninstall) {
+                    Write-Warning -Message 'Unable to find uninstall information for OneDrive.'
+                } else {
+                    Write-Verbose "Found '$($uninstall.DisplayName)'"
+                    # Find OneDrive ADMX folder
+                    Write-Verbose 'Grabbing installation path for OneDrive installer'
+                    $installfolder = $uninstall.DisplayIcon.Substring(0, $uninstall.DisplayIcon.IndexOf('\OneDriveSetup.exe'))
+                    Write-Verbose "Found '$($installfolder)'"
+                }
+            } else {
+                $installfolder = $oneDriveADMXFolder
+            }
+
+            # copy
+            $SourceAdmx = "$($installfolder)\adm"
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            if (-not (Test-Path -Path "$($TargetAdmx)")) { $null = (New-Item -Path "$($TargetAdmx)" -ItemType Directory -Force) }
+
+            Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($TargetAdmx)'"
+            Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($TargetAdmx)" -Force
+            foreach ($language in $Languages) {
+                if (-not (Test-Path -Path "$($SourceAdmx)\$($language)") -and -not (Test-Path -Path "$($SourceAdmx)\$($language.Substring(0,2))")) {
+                    if ($language -notlike 'en-us') { Write-Warning "Language '$($language)' not found for '$($ProductName)'. Processing 'en-US' instead." }
+                    if (-not (Test-Path -Path "$($TargetAdmx)\en-US")) { $null = (New-Item -Path "$($TargetAdmx)\en-US" -ItemType Directory -Force) }
+                    Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($TargetAdmx)\en-US" -Force
+                } else {
+                    $sourcelanguage = $language; if (-not (Test-Path -Path "$($SourceAdmx)\$($language)")) { $sourcelanguage = $language.Substring(0, 2) }
+                    if (-not (Test-Path -Path "$($TargetAdmx)\$($language)")) { $null = (New-Item -Path "$($TargetAdmx)\$($language)" -ItemType Directory -Force) }
+                    Copy-Item -Path "$($SourceAdmx)\$($sourcelanguage)\*.adml" -Destination "$($TargetAdmx)\$($language)" -Force
+                }
+            }
+
+            if ($PolicyStore) {
+                Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($PolicyStore)'"
+                Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($PolicyStore)" -Force
+                foreach ($language in $Languages) {
+                    if (-not (Test-Path -Path "$($SourceAdmx)\$($language)") -and -not (Test-Path -Path "$($SourceAdmx)\$($language.Substring(0,2))")) {
+                        if (-not (Test-Path -Path "$($PolicyStore)en-US")) { $null = (New-Item -Path "$($PolicyStore)en-US" -ItemType Directory -Force) }
+                        Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($PolicyStore)en-US" -Force
+                    } else {
+                        $sourcelanguage = $language; if (-not (Test-Path -Path "$($SourceAdmx)\$($language)")) { $sourcelanguage = $language.Substring(0, 2) }
+                        if (-not (Test-Path -Path "$($PolicyStore)$($language)")) { $null = (New-Item -Path "$($PolicyStore)$($language)" -ItemType Directory -Force) }
+                        Copy-Item -Path "$($SourceAdmx)\$($sourcelanguage)\*.adml" -Destination "$($PolicyStore)$($language)" -Force
+                    }
+                }
+            }
+
+            if (-not $PreferLocalOneDrive) {
+                # uninstall
+                Write-Verbose 'Uninstalling OneDrive installer'
+                $null = Start-Process -FilePath "$($installfolder)\OneDriveSetup.exe" -ArgumentList '/uninstall /allusers' -PassThru -Wait
+            }
+
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        # version already processed
+        return $null
+    }
+}
+function Invoke-EvergreenAdmx365Apps {
+    <#
+    .SYNOPSIS
+        Download Microsoft 365 Apps policy definition files
+
+    .PARAMETER Version
+        Current Version present
+
+    .PARAMETER PolicyStore
+        Destination for the Admx files
+
+    .PARAMETER Architecture
+        Architecture (x86 or x64)
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string]$Architecture = 'x64',
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmx365Apps | Where-Object { $_.Architecture -like $Architecture }
+    $ProductName = "Microsoft 365 Apps $($Architecture)"
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    # see if this is a newer version
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        # download and process
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
+            # download
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
+
+            # extract
+            Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\office'"
+            $null = Start-Process -FilePath $OutFile -ArgumentList "/quiet /norestart /extract:`"$($env:TEMP)\office`"" -PassThru -Wait
+
+            # copy
+            $SourceAdmx = "$($env:TEMP)\office\admx"
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+
+            # cleanup
+            Remove-Item -Path "$($env:TEMP)\office" -Recurse -Force
+
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        # version already processed
+        return $null
+    }
+}
+
+function Invoke-EvergreenAdmxFSLogix {
+    <#
+    .SYNOPSIS
+        Process Microsoft FSLogix Admx files
+
+    .PARAMETER Version
+        Current Version present
+
+    .PARAMETER PolicyStore
+        Destination for the Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxFSLogix
+    $ProductName = 'Microsoft FSLogix'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    # see if this is a newer version
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        # download and process
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
+            # download
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
+
+            # extract
+            Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\$($ProductName)'"
+            Expand-Archive -Path $OutFile -DestinationPath "$($env:TEMP)\$($ProductName)" -Force
+
+            # copy
+            $SourceAdmx = "$($env:TEMP)\$($ProductName)"
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            if (-not (Test-Path -Path "$($TargetAdmx)\en-US")) { $null = (New-Item -Path "$($TargetAdmx)\en-US" -ItemType Directory -Force) }
+
+            Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($TargetAdmx)'"
+            Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($TargetAdmx)" -Force
+            Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($TargetAdmx)\en-US" -Force
+            if ($PolicyStore) {
+                Write-Verbose "Copying Admx files from '$($SourceAdmx)' to '$($PolicyStore)'"
+                Copy-Item -Path "$($SourceAdmx)\*.admx" -Destination "$($PolicyStore)" -Force
+                if (-not (Test-Path -Path "$($PolicyStore)en-US")) { $null = (New-Item -Path "$($PolicyStore)en-US" -ItemType Directory -Force) }
+                Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($PolicyStore)en-US" -Force
+            }
+
+            # cleanup
+            Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
+
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        # version already processed
+        return $null
+    }
+}
+
+function Invoke-EvergreenAdmxChrome {
+    <#
+    .SYNOPSIS
+        Download Google Chrome policy definition files.
+
+    .PARAMETER Version
+        Get version of Google Chrome policy definition files.
 
     .PARAMETER PolicyStore
         Destination for the Admx files
@@ -1969,71 +1621,63 @@ function Get-GoogleChromeAdmx
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-GoogleChromeAdmxOnline
-    $ProductName = "Google Chrome"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxChrome
+    $ProductName = 'Google Chrome'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
-    # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    # See if this is a newer version
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
-
-        # download and process
         $OutFile = "$($WorkingDirectory)\downloads\googlechromeadmx.zip"
-        try
-        {
-            # download
+
+        try {
+            # Download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
 
-            # extract
+            # Extract
             Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\chromeadmx'"
             Expand-Archive -Path $OutFile -DestinationPath "$($env:TEMP)\chromeadmx" -Force
 
-            # copy
+            # Copy
             $SourceAdmx = "$($env:TEMP)\chromeadmx\windows\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
             Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
 
-            # cleanup
+            # Cleanup
             Remove-Item -Path "$($env:TEMP)\chromeadmx" -Recurse -Force
 
-            # chrome update admx is a seperate download
-            $url = "https://dl.google.com/dl/update2/enterprise/googleupdateadmx.zip"
+            # Chrome update admx is a separate download
+            $url = 'https://dl.google.com/dl/update2/enterprise/googleupdateadmx.zip'
 
-            # download
+            # Download
             $OutFile = "$($WorkingDirectory)\downloads\googlechromeupdateadmx.zip"
             Write-Verbose "Downloading '$($url)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $url -UseBasicParsing -OutFile $OutFile
 
-            # extract
+            # Extract
             Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\chromeupdateadmx'"
             Expand-Archive -Path $OutFile -DestinationPath "$($env:TEMP)\chromeupdateadmx" -Force
 
-            # copy
+            # Copy
             $SourceAdmx = "$($env:TEMP)\chromeupdateadmx\GoogleUpdateAdmx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
             Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Quiet -Languages $Languages
 
-            # cleanup
+            # Cleanup
             Remove-Item -Path "$($env:TEMP)\chromeupdateadmx" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
-        # version already processed
+    } else {
+        # Version already processed
         return $null
     }
 }
 
-function Get-AdobeAcrobatAdmx
-{
+function Invoke-EvergreenAdmxAdobeAcrobat {
     <#
     .SYNOPSIS
         Process Adobe Acrobat Admx files
@@ -2047,23 +1691,20 @@ function Get-AdobeAcrobatAdmx
 
     param(
         [string]$Version,
-        [string]$PolicyStore = $null,
-        [string[]]$Languages = $null
+        [string]$PolicyStore = $null
     )
 
-    $Evergreen = Get-AdobeAcrobatAdmxOnline
-    $ProductName = "Adobe Acrobat"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxAdobeAcrobat
+    $ProductName = 'Adobe Acrobat'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2081,21 +1722,16 @@ function Get-AdobeAcrobatAdmx
             Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-AdobeReaderAdmx
-{
+function Invoke-EvergreenAdmxAdobeReader {
     <#
     .SYNOPSIS
         Process Adobe Reader Admx files
@@ -2109,23 +1745,20 @@ function Get-AdobeReaderAdmx
 
     param(
         [string]$Version,
-        [string]$PolicyStore = $null,
-        [string[]]$Languages = $null
+        [string]$PolicyStore = $null
     )
 
-    $Evergreen = Get-AdobeReaderAdmxOnline
-    $ProductName = "Adobe Reader"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxAdobeReader
+    $ProductName = 'Adobe Reader'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2143,21 +1776,16 @@ function Get-AdobeReaderAdmx
             Remove-Item -Path "$($env:TEMP)\AdobeReader" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-CitrixWorkspaceAppAdmx
-{
+function Invoke-EvergreenAdmxWorkspaceApp {
     <#
     .SYNOPSIS
         Process Citrix Workspace App Admx files
@@ -2175,19 +1803,17 @@ function Get-CitrixWorkspaceAppAdmx
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-CitrixWorkspaceAppAdmxOnline
-    $ProductName = "Citrix Workspace App"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxWorkplaceApp
+    $ProductName = 'Citrix Workspace App'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("?")[0].Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('?')[0].Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2198,7 +1824,7 @@ function Get-CitrixWorkspaceAppAdmx
 
             # copy
             # $SourceAdmx = "$($env:TEMP)\citrixworkspaceapp\$($Evergreen.URI.Split("/")[-2].Split("?")[0].SubString(0,$Evergreen.URI.Split("/")[-2].Split("?")[0].IndexOf(".")))"
-            $SourceAdmx = (Get-ChildItem -Path "$($env:TEMP)\citrixworkspaceapp\$($Evergreen.URI.Split("/")[-2].Split("?")[0].SubString(0,$Evergreen.URI.Split("/")[-2].Split("?")[0].IndexOf(".")))" -Include "*.admx" -Recurse)[0].DirectoryName
+            $SourceAdmx = (Get-ChildItem -Path "$($env:TEMP)\citrixworkspaceapp\$($Evergreen.URI.Split('/')[-2].Split('?')[0].SubString(0,$Evergreen.URI.Split('/')[-2].Split('?')[0].IndexOf('.')))" -Include '*.admx' -Recurse)[0].DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
             Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
 
@@ -2206,21 +1832,16 @@ function Get-CitrixWorkspaceAppAdmx
             Remove-Item -Path "$($env:TEMP)\citrixworkspaceapp" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-MozillaFirefoxAdmx
-{
+function Invoke-EvergreenAdmxFirefox {
     <#
     .SYNOPSIS
         Process Mozilla Firefox Admx files
@@ -2238,19 +1859,17 @@ function Get-MozillaFirefoxAdmx
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-MozillaFirefoxAdmxOnline
-    $ProductName = "Mozilla Firefox"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxFirefox
+    $ProductName = 'Mozilla Firefox'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2268,24 +1887,19 @@ function Get-MozillaFirefoxAdmx
             Remove-Item -Path "$($env:TEMP)\firefoxadmx" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-ZoomDesktopClientAdmx
-{
+function Invoke-EvergreenAdmxZoom {
     <#
     .SYNOPSIS
-        Process Zoom Desktop Client Admx files
+        Process Zoom Admx files
 
     .PARAMETER Version
         Current Version present
@@ -2296,23 +1910,20 @@ function Get-ZoomDesktopClientAdmx
 
     param(
         [string]$Version,
-        [string]$PolicyStore = $null,
-        [string[]]$Languages = $null
+        [string]$PolicyStore = $null
     )
 
-    $Evergreen = Get-ZoomDesktopClientAdmxOnline
-    $ProductName = "Zoom Desktop Client"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxZoom
+    $ProductName = 'Zoom'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2339,21 +1950,79 @@ function Get-ZoomDesktopClientAdmx
             Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-BIS-FAdmx
-{
+function Invoke-EvergreenAdmxZoomVDI {
+    <#
+    .SYNOPSIS
+        Process Zoom VDI Admx files
+
+    .PARAMETER Version
+        Current Version present
+
+    .PARAMETER PolicyStore
+        Destination for the Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxZoomVDI
+    $ProductName = 'Zoom VDI'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    # see if this is a newer version
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        # download and process
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
+            # download
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
+
+            # extract
+            Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\$($ProductName)'"
+            Expand-Archive -Path $OutFile -DestinationPath "$($env:TEMP)\$($ProductName)" -Force
+
+            # cleanup folder structure
+            $SourceAdmx = Get-ChildItem -Path "$($env:TEMP)\$($ProductName)\" -Exclude *.adm -Include *.admx -Recurse | Where-Object { -Not $_.PSIsContainer }
+            $SourceAdml = Get-ChildItem -Path "$($env:TEMP)\$($ProductName)\" -Exclude *.adm -Include *.adml -Recurse | Where-Object { -Not $_.PSIsContainer }
+            $null = (New-Item -Path "$($env:TEMP)\clean-$($ProductName)\" -ItemType Directory -Force)
+            $null = (New-Item -Path "$($env:TEMP)\clean-$($ProductName)\en-us" -ItemType Directory -Force)
+            Copy-Item -Path $SourceAdmx -Destination "$($env:TEMP)\clean-$($ProductName)\" -Force
+            Copy-Item -Path $SourceAdml -Destination "$($env:TEMP)\clean-$($ProductName)\en-us" -Force
+            Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
+            Rename-Item -Path "$($env:TEMP)\clean-$($ProductName)" -NewName "$($ProductName)" -Force
+            # copy
+            $SourceAdmx = "$($env:TEMP)\$($ProductName)"
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+
+            # cleanup
+            Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
+
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        # version already processed
+        return $null
+    }
+}
+
+function Invoke-EvergreenAdmxBISF {
     <#
     .SYNOPSIS
         Process BIS-F Admx files
@@ -2367,23 +2036,20 @@ function Get-BIS-FAdmx
 
     param(
         [string]$Version,
-        [string]$PolicyStore = $null,
-        [string[]]$Languages = $null
+        [string]$PolicyStore = $null
     )
 
-    $Evergreen = Get-BIS-FAdmxOnline
-    $ProductName = "BIS-F"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxBISF
+    $ProductName = 'BIS-F'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
         $OutFile = "$($WorkingDirectory)\downloads\bis-f.$($Evergreen.Version).zip"
-        try
-        {
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2393,7 +2059,7 @@ function Get-BIS-FAdmx
             Expand-Archive -Path $OutFile -DestinationPath "$($env:TEMP)\bisfadmx" -Force
 
             # find extraction folder
-            Write-Verbose "Finding extraction folder"
+            Write-Verbose 'Finding extraction folder'
             $folder = (Get-ChildItem -Path "$($env:TEMP)\bisfadmx" | Sort-Object LastWriteTime -Descending)[0].Name
 
             # copy
@@ -2405,21 +2071,16 @@ function Get-BIS-FAdmx
             Remove-Item -Path "$($env:TEMP)\bisfadmx" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-MDOPAdmx
-{
+function Invoke-EvergreenAdmxMDOP {
     <#
     .SYNOPSIS
         Process MDOP Admx files
@@ -2437,19 +2098,17 @@ function Get-MDOPAdmx
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-MDOPAdmxOnline
-    $ProductName = "Microsoft Desktop Optimization Pack"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxMDOP
+    $ProductName = 'Microsoft Desktop Optimization Pack'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2460,14 +2119,14 @@ function Get-MDOPAdmx
             $null = (expand "$($OutFile)" -F:* "$($env:TEMP)\mdopadmx")
 
             # find app-v folder
-            Write-Verbose "Finding App-V folder"
-            $appvfolder = (Get-ChildItem -Path "$($env:TEMP)\mdopadmx" -Filter "App-V*" | Sort-Object Name -Descending)[0].Name
+            Write-Verbose 'Finding App-V folder'
+            $appvfolder = (Get-ChildItem -Path "$($env:TEMP)\mdopadmx" -Filter 'App-V*' | Sort-Object Name -Descending)[0].Name
 
-            Write-Verbose "Finding MBAM folder"
-            $mbamfolder = (Get-ChildItem -Path "$($env:TEMP)\mdopadmx" -Filter "MBAM*" | Sort-Object Name -Descending)[0].Name
+            Write-Verbose 'Finding MBAM folder'
+            $mbamfolder = (Get-ChildItem -Path "$($env:TEMP)\mdopadmx" -Filter 'MBAM*' | Sort-Object Name -Descending)[0].Name
 
-            Write-Verbose "Finding UE-V folder"
-            $uevfolder = (Get-ChildItem -Path "$($env:TEMP)\mdopadmx" -Filter "UE-V*" | Sort-Object Name -Descending)[0].Name
+            Write-Verbose 'Finding UE-V folder'
+            $uevfolder = (Get-ChildItem -Path "$($env:TEMP)\mdopadmx" -Filter 'UE-V*' | Sort-Object Name -Descending)[0].Name
 
             # copy
             $SourceAdmx = "$($env:TEMP)\mdopadmx\$($appvfolder)"
@@ -2482,21 +2141,16 @@ function Get-MDOPAdmx
             Remove-Item -Path "$($env:TEMP)\mdopadmx" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-CustomPolicyAdmx
-{
+function Invoke-EvergreenAdmxCustomPolicy {
     <#
     .SYNOPSIS
         Process Custom Policy Admx files
@@ -2511,46 +2165,39 @@ function Get-CustomPolicyAdmx
     param(
         [string]$Version,
         [string]$PolicyStore = $null,
-        [string]$CustomPolicyStore,
+        [string]$AddAdmxPath,
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-CustomPolicyOnline -CustomPolicyStore $CustomPolicyStore
-    $ProductName = "Custom Policy Store"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-CustomPolicyOnline -CustomPolicyStore $AddAdmxPath
+    $ProductName = 'Custom Policy Store'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        try
-        {
+        try {
             # copy
             $SourceAdmx = "$($Evergreen.URI)"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
             Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName "$($ProductName)" -Languages $Languages
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-AzureVirtualDesktopAdmx
-{
+function Invoke-EvergreenAdmxAvd {
     <#
     .SYNOPSIS
-    Process Azure Virtual Desktop Admx files
+    Process Microsoft AVD Admx files
 
     .PARAMETER Version
         Current Version present
@@ -2565,24 +2212,22 @@ function Get-AzureVirtualDesktopAdmx
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-AzureVirtualDesktopAdmxOnline
-    $ProductName = "Azure Virtual Desktop"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxAVD
+    $ProductName = 'Microsoft AVD'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
         $OutFile = "$($WorkingDirectory)\downloads\$($ProductName).cab"
         $ZipFile = "$($WorkingDirectory)\downloads\AVDGPTemplate.zip"
-        try
-        {
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
-            Invoke-Download -URL $Evergreen.URI -Destination "$($WorkingDirectory)\downloads" -FileName "$($ProductName).cab"
-            #Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
+            #Invoke-Download -URL $Evergreen.URI -Destination "$($WorkingDirectory)\downloads" -FileName "$($ProductName).cab"
+            Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
 
             # extract
             Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\$($ProductName)'"
@@ -2600,21 +2245,16 @@ function Get-AzureVirtualDesktopAdmx
             Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
-function Get-WingetAdmx
-{
+function Invoke-EvergreenAdmxWinget {
     <#
     .SYNOPSIS
         Process Winget-cli Admx files
@@ -2632,19 +2272,17 @@ function Get-WingetAdmx
         [string[]]$Languages = $null
     )
 
-    $Evergreen = Get-WingetAdmxOnline
-    $ProductName = "Microsoft winget-cli"
-    $ProductFolder = ""; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+    $Evergreen = Get-EvergreenAdmxWinget
+    $ProductName = 'Microsoft Winget'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
 
     # see if this is a newer version
-    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version)
-    {
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
         Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
 
         # download and process
-        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split("/")[-1])"
-        try
-        {
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
             # download
             Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
             Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
@@ -2662,228 +2300,329 @@ function Get-WingetAdmx
             Remove-Item -Path "$($env:TEMP)\wingetadmx" -Recurse -Force
 
             return $Evergreen
-        }
-        catch
-        {
+        } catch {
             Throw $_
         }
-    }
-    else
-    {
+    } else {
         # version already processed
         return $null
     }
 }
 
+function Invoke-EvergreenAdmxBrave {
+    <#
+    .SYNOPSIS
+        Process Brave Admx files
+
+    .PARAMETER Version
+        Current Version present
+
+    .PARAMETER PolicyStore
+        Destination for the Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxBrave
+    $ProductName = 'Brave Browser'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    # see if this is a newer version
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        # download and process
+        $OutFile = "$($WorkingDirectory)\downloads\$($Evergreen.URI.Split('/')[-1])"
+        try {
+            # download
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-WebRequest -UseDefaultCredentials -Uri $Evergreen.URI -UseBasicParsing -OutFile $OutFile
+
+            # extract
+            Write-Verbose "Extracting '$($OutFile)' to '$($env:TEMP)\braveadmx'"
+            Expand-Archive -Path $OutFile -DestinationPath "$($env:TEMP)\braveadmx" -Force
+
+            # fix policyNamespaces to support Intune ingest
+            Write-Verbose 'Fixing policyNamespaces in brave.admx'
+            [xml]$xml = (Get-Content -Path "$($env:TEMP)\braveadmx\windows\admx\brave.admx") -replace 'Brave:Cat_Brave', 'brave:Cat_Brave' | Where-Object { $_ -notmatch '^\s*<using' }
+            $newCategory = $xml.CreateElement('category')
+            $newCategory.SetAttribute('displayName', '$(string.brave)')
+            $newCategory.SetAttribute('name', 'Cat_Brave')
+            $xml.policyDefinitions.categories.AppendChild($newCategory)
+            $xml.Save("$($env:TEMP)\braveadmx\windows\admx\brave.admx")
+
+            # copy
+            $SourceAdmx = "$($env:TEMP)\braveadmx\windows\admx"
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+
+            # cleanup
+            Remove-Item -Path "$($env:TEMP)\braveadmx" -Recurse -Force
+
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        # version already processed
+        return $null
+    }
+}
+
+# Helper function to update ADMX versions
+function Update-AdmxVersion {
+    <#
+    .SYNOPSIS
+        Updates the ADMX versions object with new version information
+
+    .PARAMETER AdmxVersions
+        The ADMX versions object to update
+
+    .PARAMETER ProductKey
+        The product key to update
+
+    .PARAMETER AdmxData
+        The new ADMX data
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ref]$AdmxVersions,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProductKey,
+
+        [Parameter(Mandatory = $false)]
+        $AdmxData
+    )
+
+    if ($null -ne $AdmxData) {
+        if ($PSCmdlet.ShouldProcess("$ProductKey ADMX version", 'Update')) {
+            # Check if AdmxVersions.Value is null and initialize if needed
+            if ($null -eq $AdmxVersions.Value) {
+                $AdmxVersions.Value = @{}
+            }
+
+            # Check if the product key exists
+            if ($AdmxVersions.Value.ContainsKey($ProductKey)) {
+                $AdmxVersions.Value.$ProductKey = @{
+                    Version = $AdmxData.Version
+                    URI = $AdmxData.URI
+                }
+            } else {
+                # Add new product key if it doesn't exist
+                $AdmxVersions.Value += @{
+                    $ProductKey = @{
+                        Version = $AdmxData.Version
+                        URI = $AdmxData.URI
+                    }
+                }
+            }
+        }
+    }
+}
 #endregion
 
 #region execution
 # Custom Policy Store
-if ($Include -notcontains 'Custom Policy Store')
-{
+if ($Include -notcontains 'Custom Policy Store') {
     Write-Verbose "`nSkipping Custom Policy Store"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Custom Policy Store"
     $currentversion = $null
-    if ($admxversions.PSObject.properties -match 'CustomPolicyStore') { $currentversion = $admxversions.CustomPolicyStore.Version }
-    $admx = Get-CustomPolicyAdmx -Version $currentversion -PolicyStore $PolicyStore -CustomPolicyStore $CustomPolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.CustomPolicyStore) { $admxversions.CustomPolicyStore = $admx } else { $admxversions += @{ CustomPolicyStore = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    if ($AdmxVersions.PSObject.properties -match 'CustomPolicyStore') { $currentversion = $AdmxVersions.CustomPolicyStore.Version }
+    $admx = Invoke-EvergreenAdmxCustomPolicy -Version $currentversion -PolicyStore $PolicyStore -CustomPolicyStore $AddAdmxPath -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'CustomPolicyStore' -AdmxData $admx
 }
 
 # Windows 10
-if ($Include -notcontains 'Windows 10')
-{
+if ($Include -notcontains 'Windows 10') {
     Write-Verbose "`nSkipping Windows 10"
-}
-else
-{
-    Write-Verbose "`nProcessing Admx files for Windows 10 $($Windows10Version)"
-    $admx = Get-WindowsAdmx -Version $admxversions.Windows10.Version -PolicyStore $PolicyStore -WindowsVersion $Windows10Version -WindowsEdition 10 -Languages $Languages
-    if ($admx) { if ($admxversions.Windows10) { $admxversions.Windows10 = $admx } else { $admxversions += @{ Windows10 = @{ Version = $admx.Version; URI = $admx.URI } } } }
+} else {
+    Write-Verbose "`nProcessing Admx files for Windows 10 $($Windows10FeatureVersion)"
+    $admx = Invoke-EvergreenAdmxWindows -Version $AdmxVersions.Windows.Version -PolicyStore $PolicyStore -WindowsFeatureVersion $Windows10FeatureVersion -WindowsVersion 10 -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Windows10' -AdmxData $admx
 }
 
 # Windows 11
-if ($Include -notcontains 'Windows 11')
-{
+if ($Include -notcontains 'Windows 11') {
     Write-Verbose "`nSkipping Windows 11"
+} else {
+    Write-Verbose "`nProcessing Admx files for Windows 11 $($Windows11FeatureVersion)"
+    $admx = Invoke-EvergreenAdmxWindows -Version $AdmxVersions.Windows.Version -PolicyStore $PolicyStore -WindowsFeatureVersion $Windows11FeatureVersion -WindowsVersion 11 -Languages $Languages
+    if ($null -ne $admx) {
+        Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Windows11' -AdmxData $admx
+    } else {
+        Write-Warning 'Failed to retrieve Windows 11 ADMX files. Skipping update.'
+    }
 }
-else
-{
-    Write-Verbose "`nProcessing Admx files for Windows 11 $($Windows11Version)"
-    $admx = Get-WindowsAdmx -Version $admxversions.Windows11.Version -PolicyStore $PolicyStore -WindowsVersion $Windows11Version -WindowsEdition 11 -Languages $Languages
-    if ($admx) { if ($admxversions.Windows11) { $admxversions.Windows11 = $admx } else { $admxversions += @{ Windows11 = @{ Version = $admx.Version; URI = $admx.URI } } } }
+
+# Windows 2025
+if ($Include -notcontains 'Windows 2025') {
+    Write-Verbose "`nSkipping Windows Server 2025"
+} else {
+    Write-Verbose "`nProcessing Admx files for Windows Server 2025"
+    $admx = Invoke-EvergreenAdmxWindows -Version $AdmxVersions.Windows.Version -PolicyStore $PolicyStore -WindowsVersion 2025 -Languages $Languages
+    if ($null -ne $admx) {
+        Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Windows2025' -AdmxData $admx
+    } else {
+        Write-Warning 'Failed to retrieve Windows Server 2025 ADMX files. Skipping update.'
+    }
 }
 
 # Microsoft Edge
-if ($Include -notcontains 'Microsoft Edge')
-{
+if ($Include -notcontains 'Microsoft Edge') {
     Write-Verbose "`nSkipping Microsoft Edge"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Microsoft Edge"
-    $admx = Get-MicrosoftEdgeAdmx -Version $admxversions.Edge.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.Edge) { $admxversions.Edge = $admx } else { $admxversions += @{ Edge = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxEdge -Version $AdmxVersions.Edge.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Edge' -AdmxData $admx
 }
 
 # Microsoft OneDrive
-if ($Include -notcontains 'Microsoft OneDrive')
-{
+if ($Include -notcontains 'Microsoft OneDrive') {
     Write-Verbose "`nSkipping Microsoft OneDrive"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Microsoft OneDrive"
-    $admx = Get-OneDriveAdmx -Version $admxversions.OneDrive.Version -PolicyStore $PolicyStore -PreferLocalOneDrive $PreferLocalOneDrive -Languages $Languages
-    if ($admx) { if ($admxversions.OneDrive) { $admxversions.OneDrive = $admx } else { $admxversions += @{ OneDrive = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxOneDrive -Version $AdmxVersions.OneDrive.Version -PolicyStore $PolicyStore -PreferLocalOneDrive -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'OneDrive' -AdmxData $admx
 }
 
-# Microsoft Office
-if ($Include -notcontains 'Microsoft Office')
-{
-    Write-Verbose "`nSkipping Microsoft Office"
-}
-else
-{
-    Write-Verbose "`nProcessing Admx files for Microsoft Office"
-    $admx = Get-MicrosoftOfficeAdmx -Version $admxversions.Office.Version -PolicyStore $PolicyStore -Architecture "x64" -Languages $Languages
-    if ($admx) { if ($admxversions.Office) { $admxversions.Office = $admx } else { $admxversions += @{ Office = @{ Version = $admx.Version; URI = $admx.URI } } } }
+# Microsoft 365
+if ($Include -notcontains 'Microsoft 365 Apps') {
+    Write-Verbose "`nSkipping Microsoft 365 Apps"
+} else {
+    Write-Verbose "`nProcessing Admx files for Microsoft 365 Apps"
+    $admx = Invoke-EvergreenAdmx365Apps -Version $AdmxVersions['365Apps'].Version -PolicyStore $PolicyStore -Architecture 'x64' -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey '365Apps' -AdmxData $admx
 }
 
-# FSLogix
-if ($Include -notcontains 'FSLogix')
-{
-    Write-Verbose "`nSkipping FSLogix"
-}
-else
-{
-    Write-Verbose "`nProcessing Admx files for FSLogix"
-    $admx = Get-FSLogixAdmx -Version $admxversions.FSLogix.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.FSLogix) { $admxversions.FSLogix = $admx } else { $admxversions += @{ FSLogix = @{ Version = $admx.Version; URI = $admx.URI } } } }
+# Microsoft FSLogix
+if ($Include -notcontains 'Microsoft FSLogix') {
+    Write-Verbose "`nSkipping Microsoft FSLogix"
+} else {
+    Write-Verbose "`nProcessing Admx files for Microsoft FSLogix"
+    $admx = Invoke-EvergreenAdmxFSLogix -Version $AdmxVersions.FSLogix.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'FSLogix' -AdmxData $admx
 }
 
 # Adobe Acrobat
-if ($Include -notcontains 'Adobe Acrobat')
-{
+if ($Include -notcontains 'Adobe Acrobat') {
     Write-Verbose "`nSkipping Adobe Acrobat"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Adobe Acrobat"
-    $admx = Get-AdobeAcrobatAdmx -Version $admxversions.AdobeAcrobat.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.AdobeAcrobat) { $admxversions.AdobeAcrobat = $admx } else { $admxversions += @{ AdobeAcrobat = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxAdobeAcrobat -Version $AdmxVersions.AdobeAcrobat.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'AdobeAcrobat' -AdmxData $admx
 }
 
 # Adobe Reader
-if ($Include -notcontains 'Adobe Reader')
-{
+if ($Include -notcontains 'Adobe Reader') {
     Write-Verbose "`nSkipping Adobe Reader"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Adobe Reader"
-    $admx = Get-AdobeReaderAdmx -Version $admxversions.AdobeReader.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.AdobeReader) { $admxversions.AdobeReader = $admx } else { $admxversions += @{ AdobeReader = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxAdobeReader -Version $AdmxVersions.AdobeReader.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'AdobeReader' -AdmxData $admx
 }
 
 # BIS-F
-if ($Include -notcontains 'BIS-F')
-{
+if ($Include -notcontains 'BIS-F') {
     Write-Verbose "`nSkipping BIS-F"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for BIS-F"
-    $admx = Get-BIS-FAdmx -Version $admxversions.BISF.Version -PolicyStore $PolicyStore
-    if ($admx) { if ($admxversions.BISF) { $admxversions.BISF = $admx } else { $admxversions += @{ BISF = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxBISF -Version $AdmxVersions.BISF.Version -PolicyStore $PolicyStore
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'BISF' -AdmxData $admx
 }
 
 # Citrix Workspace App
-if ($Include -notcontains 'Citrix Workspace App')
-{
+if ($Include -notcontains 'Citrix Workspace App') {
     Write-Verbose "`nSkipping Citrix Workspace App"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Citrix Workspace App"
-    $admx = Get-CitrixWorkspaceAppAdmx -Version $admxversions.CitrixWorkspaceApp.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.CitrixWorkspaceApp) { $admxversions.CitrixWorkspaceApp = $admx } else { $admxversions += @{ CitrixWorkspaceApp = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxWorkspaceApp -Version $AdmxVersions.CitrixWorkspaceApp.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'CitrixWorkspaceApp' -AdmxData $admx
 }
 
 # Google Chrome
-if ($Include -notcontains 'Google Chrome')
-{
+if ($Include -notcontains 'Google Chrome') {
     Write-Verbose "`nSkipping Google Chrome"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Google Chrome"
-    $admx = Get-GoogleChromeAdmx -Version $admxversions.GoogleChrome.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.GoogleChrome) { $admxversions.GoogleChrome = $admx } else { $admxversions += @{ GoogleChrome = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxChrome -Version $AdmxVersions.GoogleChrome.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'GoogleChrome' -AdmxData $admx
 }
 
 # Microsoft Desktop Optimization Pack
-if ($Include -notcontains 'Microsoft Desktop Optimization Pack')
-{
+if ($Include -notcontains 'Microsoft Desktop Optimization Pack') {
     Write-Verbose "`nSkipping Microsoft Desktop Optimization Pack"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Microsoft Desktop Optimization Pack"
-    $admx = Get-MDOPAdmx -Version $admxversions.MDOP.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.MDOP) { $admxversions.MDOP = $admx } else { $admxversions += @{ MDOP = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxMDOP -Version $AdmxVersions.MDOP.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'MDOP' -AdmxData $admx
 }
 
 # Mozilla Firefox
-if ($Include -notcontains 'Mozilla Firefox')
-{
+if ($Include -notcontains 'Mozilla Firefox') {
     Write-Verbose "`nSkipping Mozilla Firefox"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Mozilla Firefox"
-    $admx = Get-MozillaFirefoxAdmx -Version $admxversions.MozillaFirefox.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.MozillaFirefox) { $admxversions.MozillaFirefox = $admx } else { $admxversions += @{ MozillaFirefox = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxFirefox -Version $AdmxVersions.MozillaFirefox.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'MozillaFirefox' -AdmxData $admx
 }
 
-# Zoom Desktop Client
-if ($Include -notcontains 'Zoom Desktop Client')
-{
-    Write-Verbose "`nSkipping Zoom Desktop Client"
-}
-else
-{
-    Write-Verbose "`nProcessing Admx files for Zoom Desktop Client"
-    $admx = Get-ZoomDesktopClientAdmx -Version $admxversions.ZoomDesktopClient.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.ZoomDesktopClient) { $admxversions.ZoomDesktopClient = $admx } else { $admxversions += @{ ZoomDesktopClient = @{ Version = $admx.Version; URI = $admx.URI } } } }
+# Zoom
+if ($Include -notcontains 'Zoom') {
+    Write-Verbose "`nSkipping Zoom"
+} else {
+    Write-Verbose "`nProcessing Admx files for Zoom"
+    $admx = Invoke-EvergreenAdmxZoom -Version $AdmxVersions.Zoom.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Zoom' -AdmxData $admx
 }
 
-# Azure Virtual Desktop
-if ($Include -notcontains 'Azure Virtual Desktop')
-{
-    Write-Verbose "`nSkipping Azure Virtual Desktop"
-}
-else
-{
-    Write-Verbose "`nProcessing Admx files for Azure Virtual Desktop"
-    $admx = Get-AzureVirtualDesktopAdmx -Version $admxversions.AzureVirtualDesktop.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.AzureVirtualDesktop) { $admxversions.AzureVirtualDesktop = $admx } else { $admxversions += @{ AzureVirtualDesktop = @{ Version = $admx.Version; URI = $admx.URI } } } }
+# Zoom VDI
+if ($Include -notcontains 'Zoom VDI') {
+    Write-Verbose "`nSkipping Zoom VDI"
+} else {
+    Write-Verbose "`nProcessing Admx files for Zoom VDI"
+    $admx = Invoke-EvergreenAdmxZoomVDI -Version $AdmxVersions.ZoomVDI.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Zoom VDI' -AdmxData $admx
 }
 
-# Microsoft winget-cli
-if ($Include -notcontains 'Microsoft Winget')
-{
+# Microsoft AVD
+if ($Include -notcontains 'Microsoft AVD') {
+    Write-Verbose "`nSkipping Microsoft Azure Virtual Desktop"
+} else {
+    Write-Verbose "`nProcessing Admx files for Microsoft Azure Virtual Desktop"
+    $admx = Invoke-EvergreenAdmxAvd -Version $AdmxVersions.AzureVirtualDesktop.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'AzureVirtualDesktop' -AdmxData $admx
+}
+
+# Microsoft Winget
+if ($Include -notcontains 'Microsoft Winget') {
     Write-Verbose "`nSkipping Microsoft Winget"
-}
-else
-{
+} else {
     Write-Verbose "`nProcessing Admx files for Microsoft Winget"
-    $admx = Get-WingetAdmx -Version $admxversions.Winget.Version -PolicyStore $PolicyStore -Languages $Languages
-    if ($admx) { if ($admxversions.Winget) { $admxversions.Winget = $admx } else { $admxversions += @{ Winget = @{ Version = $admx.Version; URI = $admx.URI } } } }
+    $admx = Invoke-EvergreenAdmxWinget -Version $AdmxVersions.Winget.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Winget' -AdmxData $admx
 }
 
-Write-Verbose "`nSaving Admx versions to '$($WorkingDirectory)\admxversions.xml'"
-$admxversions | Export-Clixml -Path "$($WorkingDirectory)\admxversions.xml" -Force
+# Brave Browser
+if ($Include -notcontains 'Brave Browser') {
+    Write-Verbose "`nSkipping Brave Browser"
+} else {
+    Write-Verbose "`nProcessing Admx files for Brave Browser"
+    $admx = Invoke-EvergreenAdmxBrave -Version $AdmxVersions.Brave.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Brave' -AdmxData $admx
+}
+
+Write-Verbose "`nSaving Admx versions to '$($WorkingDirectory)\AdmxVersions.xml'"
+$AdmxVersions | Export-Clixml -Path "$($WorkingDirectory)\AdmxVersions.xml" -Force
+#endregion
+#endregion
+#endregion
+#endregion
+#endregion
 #endregion

--- a/EvergreenAdmx.ps1
+++ b/EvergreenAdmx.ps1
@@ -9,7 +9,6 @@
 
 .LICENSEURI https://github.com/msfreaks/EvergreenAdmx/blob/main/LICENSE
 
-.PROJECTURI https://github.com/msfreaks/EvergreenAdmx
 #>
 
 <#
@@ -21,7 +20,8 @@
     Optionally copies the latest Admx files to a folder of your choosing, for example a Policy Store.
 
 .PARAMETER WindowsVersion
-    Specifies Windows major version. Supports 10, 11 or 2025. Default is 11.
+    Specifies Windows major version. Supports 10, 11 or 2025.
+    Default is 11.
 
 .PARAMETER Windows10FeatureVersion
     Specifies Windows 10 feature version to get the Admx files for. This parameter is used when 'Windows 10' is included.
@@ -39,7 +39,7 @@
     Specifies a Working Directory for the script.
     Admx files will be stored in a subdirectory called "admx".
     Downloaded files will be stored in a subdirectory called "downloads".
-    If omitted the script will treat the script's folder as the working directory.
+    Defaults to current script location.
 
 .PARAMETER PolicyStore
     Specifies a Policy Store location to copy the Admx files to after processing.

--- a/EvergreenAdmx.ps1
+++ b/EvergreenAdmx.ps1
@@ -20,7 +20,7 @@
     Optionally copies the latest Admx files to a folder of your choosing, for example a Policy Store.
 
 .PARAMETER WindowsVersion
-    Specifies Windows major version. Supports 10, 11 or 2025.
+    Specifies Windows major version. Supports 10, 11, 2022 or 2025.
     Default is 11.
 
 .PARAMETER Windows10FeatureVersion
@@ -59,7 +59,7 @@
 
 .PARAMETER Include
     Array containing Admx products to include when checking for updates.
-    Valid values are: "Windows 10", "Windows 11", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
+    Valid values are: "Windows 10", "Windows 11", "Windows 2022", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
     Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps".
 
 .PARAMETER PreferLocalOneDrive
@@ -94,7 +94,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $False, Position = 0)]
-    [ValidateSet('10', '11', '2025')]
+    [ValidateSet('10', '11', '2022', '2025')]
     [System.String] $WindowsVersion = '11',
     [Parameter(Mandatory = $False)][ValidateSet('1903', '1909', '2004', '20H2', '21H1', '21H2', '22H2')]
     [System.String] $Windows10FeatureVersion = '22H2',
@@ -113,7 +113,7 @@ param(
     [Alias('CustomPolicyStore')]
     [System.String] $AddAdmxPath = $null,
     [Parameter(Mandatory = $False)]
-    [ValidateSet('Custom Policy Store', 'Windows 10', 'Windows 11', 'Windows 2025', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps', 'Microsoft FSLogix', 'Adobe Acrobat', 'Adobe Reader', 'BIS-F', 'Citrix Workspace App', 'Google Chrome', 'Microsoft Desktop Optimization Pack', 'Mozilla Firefox', 'Zoom', 'Zoom VDI', 'Microsoft AVD', 'Microsoft Winget', 'Brave Browser')]
+    [ValidateSet('Custom Policy Store', 'Windows 10', 'Windows 11', 'Windows 2022', 'Windows 2025', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps', 'Microsoft FSLogix', 'Adobe Acrobat', 'Adobe Reader', 'BIS-F', 'Citrix Workspace App', 'Google Chrome', 'Microsoft Desktop Optimization Pack', 'Mozilla Firefox', 'Zoom', 'Zoom VDI', 'Microsoft AVD', 'Microsoft Winget', 'Brave Browser')]
     [System.String[]] $Include = @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps'),
     [Parameter(Mandatory = $False)]
     [switch] $PreferLocalOneDrive = $False
@@ -124,6 +124,8 @@ if ($WindowsVersion -eq '10' -and $PSBoundParameters.ContainsKey('Windows11Featu
     Write-Warning 'Windows11FeatureVersion parameter is ignored when WindowsVersion is set to 10'
 } elseif ($WindowsVersion -eq '11' -and $PSBoundParameters.ContainsKey('Windows10FeatureVersion')) {
     Write-Warning 'Windows10FeatureVersion parameter is ignored when WindowsVersion is set to 11'
+} elseif ($WindowsVersion -eq '2022' -and ($PSBoundParameters.ContainsKey('Windows10FeatureVersion') -or $PSBoundParameters.ContainsKey('Windows11FeatureVersion'))) {
+    Write-Warning 'Windows feature version parameters are ignored when WindowsVersion is set to 2022'
 } elseif ($WindowsVersion -eq '2025' -and ($PSBoundParameters.ContainsKey('Windows10FeatureVersion') -or $PSBoundParameters.ContainsKey('Windows11FeatureVersion'))) {
     Write-Warning 'Windows feature version parameters are ignored when WindowsVersion is set to 2025'
 }
@@ -143,6 +145,8 @@ If ($WindowsVersion -eq '10' -and $Include -notcontains 'Windows 10') {
     $Include += 'Windows 10'
 } elseif ($WindowsVersion -eq '11' -and $Include -notcontains 'Windows 11') {
     $Include += 'Windows 11'
+} elseif ($WindowsVersion -eq '2022' -and $Include -notcontains 'Windows 2022') {
+    $Include += 'Windows 2022'
 } elseif ($WindowsVersion -eq '2025' -and $Include -notcontains 'Windows 2025') {
     $Include += 'Windows 2025'
 }
@@ -638,7 +642,7 @@ function Get-WindowsDownloadId {
         Returns Windows admx download Id
 
     .PARAMETER WindowsVersion
-        Specifies Windows major version. Supports 10, 11 or 2025. Default is 11.
+        Specifies Windows major version. Supports 10, 11, 2022 or 2025. Default is 11.
 
     .PARAMETER WindowsFeatureVersion
         Specifies Windows client feature edition. Default is 24H2.
@@ -649,7 +653,7 @@ function Get-WindowsDownloadId {
 
     param (
         [Parameter(Position = 0, ValueFromPipeline = $true)]
-        [ValidateSet('10', '11', '2025')]
+        [ValidateSet('10', '11', '2022', '2025')]
         [ValidateNotNullOrEmpty()]
         [int]$WindowsVersion = '11',
         [Parameter(Position = 1, ValueFromPipeline = $true)]
@@ -658,10 +662,10 @@ function Get-WindowsDownloadId {
                     return $true
                 } elseif ($WindowsVersion -eq '11' -and $_ -in @('21H2', '22H2', '23H2', '24H2')) {
                     return $true
-                } elseif ($WindowsVersion -eq '2025') {
+                } elseif ($WindowsVersion -eq '2022' -or $WindowsVersion -eq '2025') {
                     return $true
                 } else {
-                    throw "Invalid Windows Feature Version '$_' for Windows $WindowsVersion. Windows 10 supports: 1903, 1909, 2004, 20H2, 21H1, 21H2, 22H2. Windows 11 supports: 21H2, 22H2, 23H2, 24H2. Windows 2025 has no feature editions."
+                    throw "Invalid Windows Feature Version '$_' for Windows $WindowsVersion. Windows 10 supports: 1903, 1909, 2004, 20H2, 21H1, 21H2, 22H2. Windows 11 supports: 21H2, 22H2, 23H2, 24H2. Windows 2022 and 2025 has no Windows Feature Versions."
                 }
             })]
         [ValidateNotNullOrEmpty()]
@@ -677,6 +681,10 @@ function Get-WindowsDownloadId {
             return (@( @{ '21H2' = '103507' }, @{ '22H2' = '104593' }, @{ '23H2' = '105667' }, @{ '24H2' = '106254' } ).$WindowsFeatureVersion)
             break
         }
+        2022 {
+            return @( '104003' )
+            break
+        }
         2025 {
             return @( '106295' )
             break
@@ -687,7 +695,7 @@ function Get-WindowsDownloadId {
 function Get-EvergreenAdmxWindows {
     <#
     .SYNOPSIS
-        Returns url and latest version for Windows 10, Windows 11 or Windows Server 2025 policy definitions files.
+        Returns url and latest version for Windows 10, Windows 11 or Windows Server 2022 or 2025 policy definitions files.
 
     .PARAMETER DownloadId
         Id returned from Get-WindowsDownloadId. Default is the latest version for the current Windows major version.
@@ -1236,12 +1244,12 @@ function Invoke-EvergreenAdmxWindows {
         [string[]]$Languages = $null
     )
 
-    if ($WindowsVersion -eq '2025') {
-        $id = Get-WindowsDownloadId -WindowsVersion $WindowsVersion
-        $ProductName = "Microsoft Windows $($WindowsVersion)"
-    } elseif ($WindowsVersion -eq 11 -or $WindowsVersion -eq 10) {
+    If ($WindowsVersion -eq 11 -or $WindowsVersion -eq 10) {
         $id = Get-WindowsDownloadId -WindowsVersion $WindowsVersion -WindowsFeatureVersion $WindowsFeatureVersion
         $ProductName = "Microsoft Windows $($WindowsVersion) $($WindowsFeatureVersion)"
+    } elseif ($WindowsVersion -eq '2022' -or $WindowsVersion -eq '2025') {
+        $id = Get-WindowsDownloadId -WindowsVersion $WindowsVersion
+        $ProductName = "Microsoft Windows Server $($WindowsVersion)"
     }
     $Evergreen = Get-EvergreenAdmxWindows -DownloadId $id
     $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
@@ -2458,6 +2466,19 @@ if ($Include -notcontains 'Windows 11') {
         Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Windows11' -AdmxData $admx
     } else {
         Write-Warning 'Failed to retrieve Windows 11 ADMX files. Skipping update.'
+    }
+}
+
+# Windows 2022
+if ($Include -notcontains 'Windows 2022') {
+    Write-Verbose "`nSkipping Windows Server 2022"
+} else {
+    Write-Verbose "`nProcessing Admx files for Windows Server 2022"
+    $admx = Invoke-EvergreenAdmxWindows -Version $AdmxVersions.Windows.Version -PolicyStore $PolicyStore -WindowsVersion 2022 -Languages $Languages
+    if ($null -ne $admx) {
+        Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'Windows2022' -AdmxData $admx
+    } else {
+        Write-Warning 'Failed to retrieve Windows Server 2022 ADMX files. Skipping update.'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,17 @@ You can import the sample xml file in Task Scheduler provided with this script.
 
 `Breaking change starting from 2503.1`
 
-Valid entries are "Custom Policy Store", "Windows 10", "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
+Added script parameter **WindowsVersion** that supports value **10**, **11**, **2022** and **2025**
+Replaced script parameter **Windows10Version** and **Windows11Version** by **WindowsFeatureVersion**
+Renamed product **Microsoft Office** to **Microsoft 365 Apps**
+Renamed product **Azure Virtual Desktop** to **Microsoft AVD**
+Renamed product **FSLogix** to **Microsoft FSlogix**
+Renamed product **Zoom Desktop Client** to **Zoom**
+Added admx for Windows Server 2025
+Added admx for Windows Server 2022
+Added admx for Zoom VDI
+
+Valid entries are "Custom Policy Store", "Windows 10", "Windows 11", "Windows 2022", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
 
 `Breaking change starting from 2402.1`
 
@@ -88,8 +98,8 @@ SYNOPSIS
 
 
 SYNTAX
-    N:\Intune\Scripts\EvergreenAdmx\EvergreenAdmx.ps1 [[-WindowsVersion] <String>] [-Windows10FeatureVersion <String>] [-Windows11FeatureVersion <String>] [-WorkingDirectory <String>] [-PolicyStore <String>] [-Languages <String[]>]
-    [-UseProductFolders] [-AddAdmxPath <String>] [-Include <String[]>] [-PreferLocalOneDrive] [<CommonParameters>]
+    N:\Intune\Scripts\EvergreenAdmx\EvergreenAdmx.ps1 [[-WindowsVersion] <String>] [-WindowsFeatureVersion <String>] [-WorkingDirectory <String>] [-PolicyStore <String>] [-Languages <String[]>] [-UseProductFolders] [-CustomPolicyStore <String>] [-Include <String[]>] [-PreferLocalOneDrive]
+    [<CommonParameters>]
 
 
 DESCRIPTION
@@ -99,7 +109,7 @@ DESCRIPTION
 
 PARAMETERS
     -WindowsVersion <String>
-        Specifies Windows major version. Supports 10, 11 2022 or 2025.
+        Specifies Windows major version. Supports 10, 11, 2022 or 2025.
         Default is 11.
 
         Required?                    false
@@ -109,28 +119,23 @@ PARAMETERS
         Aliases
         Accept wildcard characters?  false
 
-    -Windows10FeatureVersion <String>
-        Specifies Windows 10 feature version to get the Admx files for. This parameter is used when 'Windows 10' is included.
-        Valid values are: 1903, 1909, 2004, 20H2, 21H1, 21H2, 22H2.
-        Defaults to 22H2.
+    -WindowsFeatureVersion <String>
+        Specifies Windows 10 or 11 feature version to get the Admx files for.
+        Valid values are: 1903, 1909, 2004, 20H2, 21H1, 21H2, 22H2 for Windows 10.
+        Valid values are: 21H2, 22H2, 23H2, 24H2 for Windows 11.
+        Defaults to 24H2.
 
         Note: Windows 11 23H2 policy definitions now supports Windows 10.
 
         Required?                    false
         Position?                    named
-        Default value                22H2
-        Accept pipeline input?       false
-        Aliases
-        Accept wildcard characters?  false
-
-    -Windows11FeatureVersion <String>
-        Specifies Windows 11 feature version to get the Admx files for. This parameter is used when 'Windows 11' is included.
-        Valid values are: 21H2, 22H2, 23H2, 24H2.
-        Defaults to 24H2.
-
-        Required?                    false
-        Position?                    named
-        Default value                24H2
+        Default value                $(
+                switch ($WindowsVersion) {
+                    '10' { '22H2' }
+                    '11' { '24H2' }
+                    default { '24H2' }
+                }
+            )
         Accept pipeline input?       false
         Aliases
         Accept wildcard characters?  false
@@ -179,7 +184,7 @@ PARAMETERS
         Aliases
         Accept wildcard characters?  false
 
-    -AddAdmxPath <String>
+    -CustomPolicyStore <String>
         Specifies a location for custom policy files. Can be UNC format or local folder.
         Find .admx files in this location, and at least one language folder holding the .adml file(s).
         Versioning will be done based on the newest file found recursively in this location (any .admx or .adml).
@@ -194,13 +199,21 @@ PARAMETERS
 
     -Include <String[]>
         Array containing Admx products to include when checking for updates.
-        Valid values are: "Windows 10", "Windows 11", "Windows 2022", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft
-        Desktop Optimization Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
+        Valid values are: "Windows 10", "Windows 11", "Windows 2022", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization
+        Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
         Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps".
 
         Required?                    false
         Position?                    named
-        Default value                @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps')
+        Default value                $(
+                switch ($WindowsVersion) {
+                    '10' { @('Windows 10', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps') }
+                    '11' { @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps') }
+                    '2022' { @('Windows 2022', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps') }
+                    '2025' { @('Windows 2025', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps') }
+                    default { @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps') }
+                }
+            )
         Accept pipeline input?       false
         Aliases
         Accept wildcard characters?  false
@@ -237,18 +250,18 @@ OUTPUTS
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS > .\EvergreenAdmx.ps1 -WorkingDirectory "C:\Temp\EvergreenAdmx" -Include @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps', 'Microsoft FSLogix')
+    PS > .\EvergreenAdmx.ps1 -WindowsVersion 2025
 
-    Downloads the latest admx files for the specified products to C:\Temp\EvergreenAdmx folder.
+    Downloads the latest admx files for Windows 2025, Microsoft Edge, Microsoft OneDrive, and Microsoft 365 Apps to the current folder.
 
 
 
 
     -------------------------- EXAMPLE 3 --------------------------
 
-    PS > .\EvergreenAdmx.ps1 -WindowsVersion 2025 -Include "Windows 2025"
+    PS > .\EvergreenAdmx.ps1 -WorkingDirectory "C:\Temp\EvergreenAdmx" -Include @('Windows 11', 'Microsoft Edge', 'Microsoft OneDrive', 'Microsoft 365 Apps', 'Microsoft FSLogix')
 
-    Downloads the latest admx files for Windows 2025 to the current folder.
+    Downloads the latest admx files for the specified products to C:\Temp\EvergreenAdmx folder.
 
 
 
@@ -257,7 +270,7 @@ OUTPUTS
 
     PS > .\EvergreenAdmx.ps1 -PolicyStore "C:\Windows\SYSVOL\domain\Policies\PolicyDefinitions" -Languages @("en-US", "nl-NL") -UseProductFolders
 
-    Downloads the default set of admx files, stores them in product folders for both English and Dutch languages, and copies them to the specified Policy store.
+    Downloads the default set of products policy definitions files, stores them in product folders for both English and Dutch languages, and copies them to the specified Policy store.
 ```
 
 ## Admx files

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ DESCRIPTION
 
 PARAMETERS
     -WindowsVersion <String>
-        Specifies Windows major version. Supports 10, 11 or 2025.
+        Specifies Windows major version. Supports 10, 11 2022 or 2025.
         Default is 11.
 
         Required?                    false
@@ -194,7 +194,7 @@ PARAMETERS
 
     -Include <String[]>
         Array containing Admx products to include when checking for updates.
-        Valid values are: "Windows 10", "Windows 11", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft
+        Valid values are: "Windows 10", "Windows 11", "Windows 2022", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft
         Desktop Optimization Pack", "Mozilla Firefox", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Brave Browser".
         Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps".
 
@@ -281,6 +281,7 @@ Now supports
 - Microsoft OneDrive (local installation or Evergreen)
 - Microsoft Windows 10 (1903/1909/2004/20H2/21H1/21H2/22H2)
 - Microsoft Windows 11 (21H2/22H2/23H2/24H2)
+- Microsoft Windows Server 2022 (Aug 2021)
 - Microsoft Windows Server 2025 (Nov 2024)
 - Microsoft Winget
 - Mozilla Firefox

--- a/README.md
+++ b/README.md
@@ -7,63 +7,85 @@
 After deploying several Azure Virtual Desktop environments I decided I no longer wanted to manually download the Admx files I needed, and I wanted a way to keep them up-to-date.
 
 This script solves both problems.
-*  Checks for newer versions of the Admx files that are present and processes the new version if found
-*  Optionally copies the new Admx files to the Policy Store or Definition folder, or a folder of your choosing
+
+- Checks for newer versions of the Admx files that are present and processes the new version if found
+- Optionally copies the new Admx files to the Policy Store or Definition folder, or a folder of your choosing
 
 The name I chose for this script is an ode to the [Evergreen module](https://github.com/aaronparker/Evergreen) by Aaron Parker [@stealthpuppy](https://twitter.com/stealthpuppy).
 
 ## How to use
 
 Quick start:
-*  Download the script to a location of your choosing (for example: C:\Scripts\EvergreenAdmx)
-*  Run or schedule the script
+
+- Download the script to a location of your choosing (for example: C:\Scripts\EvergreenAdmx)
+- Run or schedule the script
 
 You can also install the script from the PowerShell Gallery [EvergreenAdmx][poshgallery-evergreenadmx] :
+
 ```powershell
 Install-Script -Name EvergreenAdmx
 ```
 
-I have scheduled the script to run daily:
+### Examples
+
+Download policy definitions files to Test directory
 
 ```powershell
-EvergreenAdmx.ps1 -PolicyStore "C:\Windows\SYSVOL\domain\Policies\PolicyDefinitions"
+.\EvergreenAdmx.ps1 -WorkingDirectory .\Test
 ```
 
-The above execution will keep the central Policy Store up-to-date on a daily basis.
+Update local group policies policy store on your DC
 
-A sample .xml file that you can import in Task Scheduler is provided with this script.
+```powershell
+.\EvergreenAdmx.ps1 -PolicyStore "C:\Windows\SYSVOL\domain\Policies\PolicyDefinitions"
+```
+
+Update local group policies
+
+```powershell
+.\EvergreenAdmx.ps1 -PolicyStore "C:\Windows\PolicyDefinitions"
+```
+
+
+```powershell
+    [array]$IncludeProducts = @("Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix")
+    .\EvergreenAdmx.ps1 -WorkingDirectory .\Test -Include $IncludeProducts -UseProductFolders
+```
+
+If you wish to run a scheduled task on a daily basis.
+You can import the sample xml file in Task Scheduler provided with this script.
+
+`Breaking change starting from 2503.1`
+
+Valid entries are "Custom Policy Store", "Windows 10", "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client", "Azure Virtual Desktop", "Microsoft Winget", "Brave Browser".
 
 `Breaking change starting from 2402.1`
 
-The -WindowsVersion parameter was added back and is now an alias of -Windows11Version
-
-Valid entries are "Custom Policy Store", "Windows 10", "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office", "FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client", "Azure Virtual Desktop".
+Valid entries are "Custom Policy Store", "Windows 10", "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client", "Azure Virtual Desktop", "Microsoft Winget".
 
 `Breaking change starting from 2301.1`
 
-Valid entries are "Custom Policy Store", "Windows 10", "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office", "FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client".
+Valid entries are "Custom Policy Store", "Windows 10", "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client".
 
 `Breaking change starting from 2112.1`
 
 Windows 11 was added to the script, and that means the -WindowsVersion parameter was substituted with -Windows10Version and -Windows11Version.
 These MUST be used and for the same Windows version as any 'Include' options you provide.
 
-From this version the 'Includes' will default to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office".
+From this version the 'Includes' will default to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps".
 
 `Breaking change starting from 2101.2`
 
 This script no longer processes all the products by default. There's no need to comment out any products you don't need anymore.
 
 In 2101.2 the parameter 'Include' was introduced which is an array you can use to specify all products that need to be processed. This parameter is required for the script to be able to run.
-Valid entries are "Custom Policy Store", "Windows 10" or "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office", "FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client", "Azure Virtual Desktop", "Microsoft Winget".
+Valid entries are "Custom Policy Store", "Windows 10" or "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "BIS-F", "Citrix Workspace App", "Google Chrome", "Microsoft Desktop Optimization Pack", "Mozilla Firefox", "Zoom Desktop Client", "Azure Virtual Desktop".
 
-By default, if you don't use this parameter, only "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office" is processed.
+By default, if you don't use this parameter, only "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps" is processed.
 
-```
+```powershell
 SYNTAX
-    C:\gits\github\EvergreenAdmx\EvergreenAdmx.ps1 [[-Windows10Version] <String>] [[-Windows11Version]
-    <String>] [[-WorkingDirectory] <String>] [[-PolicyStore] <String>] [[-Languages] <String[]>]
-    [-UseProductFolders] [[-CustomPolicyStore] <String>] [[-Include] <String[]>] [-PreferLocalOneDrive]
+    .\EvergreenAdmx.ps1 [[-WindowsVersion] <String>] [[-Windows11FeatureVersion] <String>] [[-Windows10FeatureVersion] <String>] [[-WorkingDirectory] <String>] [[-PolicyStore] <String>] [[-Languages] <String[]>] [-UseProductFolders] [[-AddAdmxPath] <String>] [[-Include] <String[]>] [-PreferLocalOneDrive]
     [<CommonParameters>]
 
 DESCRIPTION
@@ -98,8 +120,8 @@ PARAMETERS
 
     -WorkingDirectory <String>
         Optionally provide a Working Directory for the script.
-        The script will store Admx files in a subdirectory called "admx".
-        The script will store downloaded files in a subdirectory called "downloads".
+        The script will store admx files in a subdirectory called 'Admx'.
+        The script will store downloaded files in a subdirectory called 'downloads'.
         If omitted the script will treat the script's folder as the working directory.
 
         Required?                    false
@@ -150,11 +172,11 @@ PARAMETERS
 
     -Include <String[]>
         Array containing Admx products to include when checking for updates.
-        Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office" if omitted.
+        Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps" if omitted.
 
         Required?                    false
         Position?                    6
-        Default value                @("Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft Office")
+        Default value                @("Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps")
         Accept pipeline input?       false
         Accept wildcard characters?  false
 
@@ -179,7 +201,6 @@ PARAMETERS
     PS C:\>.\EvergreenAdmx.ps1 -PolicyStore "C:\Windows\SYSVOL\domain\Policies\PolicyDefinitions" -Languages @("en-US", "nl-NL") -UseProductFolders
 
     Will process the default set of products, storing results in product folders, for both English United States as Dutch languages, and copies the files to the Policy store.
-
 ```
 
 ## Admx files
@@ -187,23 +208,27 @@ PARAMETERS
 Also see [Change Log][change-log] for a list of supported products.
 
 Now supports
-*  Adobe Acrobat (Continuous Track)
-*  Adobe Reader (Continuous Track)
-*  Azure Virtual Desktop
-*  Base Image Script Framework (BIS-F)
-*  Citrix Workspace App
-*  Custom Policy Store
-*  FSLogix
-*  Google Chrome
-*  Microsoft Desktop Optimization Pack
-*  Microsoft Edge (Chromium)
-*  Microsoft Office
-*  Microsoft OneDrive (local installation or Evergreen)
-*  Microsoft Windows 10 (1903/1909/2004/20H2/21H1/21H2/22H2)
-*  Microsoft Windows 11 (21H2/22H2/23H2/24H2)
-*  Microsoft Winget
-*  Mozilla Firefox
-*  Zoom Desktop Client
+
+- Adobe Acrobat (Continuous Track)
+- Adobe Reader (Continuous Track)
+- Base Image Script Framework (BIS-F)
+- Brave Browser
+- Citrix Workspace App
+- Custom Policy Store
+- Google Chrome
+- Microsoft AVD
+- Microsoft Desktop Optimization Pack
+- Microsoft Edge (Chromium)
+- Microsoft FSLogix
+- Microsoft 365 Apps
+- Microsoft OneDrive (local installation or Evergreen)
+- Microsoft Windows 10 (1903/1909/2004/20H2/21H1/21H2/22H2)
+- Microsoft Windows 11 (21H2/22H2/23H2/24H2)
+- Microsoft Windows Server 2025 (Nov 2024)
+- Microsoft Winget
+- Mozilla Firefox
+- Zoom
+- Zoom VDI
 
 ## Notes
 


### PR DESCRIPTION
- Added script parameter **WindowsVersion** that supports value **10**, **11**, **2022** and **2025** (`breaking change`)
- Replaced script parameter **Windows10Version** and **Windows11Version** by **WindowsFeatureVersion** (`breaking change`)
- Renamed product **Microsoft Office** to **Microsoft 365 Apps** (`breaking change`)
- Renamed product **Azure Virtual Desktop** to **Microsoft AVD** (`breaking change`)
- Renamed product **FSLogix** to **Microsoft FSlogix** (`breaking change`)
- Renamed product **Zoom Desktop Client** to **Zoom** (`breaking change`)
- Improved script parameters validation
- Improved verbose logging
- Fixed issues with PreferLocalOneDrive parameter
- Added admx for Windows Server 2025
- Added admx for Windows Server 2022
- Added admx for Zoom VDI
- Renamed functions to get url and latest version of policy definitions files from Get-$ProductAdmxOnline to Get-EvergreenAdmx%Product%
- Renamed functions to download policy definitions files from Get-$ProductAdmx to Invoke-EvergreenAdmx%Product%
- Added new Update-AdmxVersion function
- Added admx for Brave Browser [#48](https://github.com/msfreaks/EvergreenAdmx/issues/48) Thanks [Tom Plant](https://github.com/pl4nty)!
- Fixed scrapping for OneDrive [#55](https://github.com/msfreaks/EvergreenAdmx/pull/55) Thanks [Tom Plant](https://github.com/pl4nty)!
- Fix Windows 11, OneDrive, and 365 apps admx downloads [#51](https://github.com/msfreaks/EvergreenAdmx/issues/51) Thanks [Tom Plant](https://github.com/pl4nty)!
- Fixed errors reported by PSScriptAnalyzer rules
- Improved code formatting based on powershell and markdown best practices