### PR TITLE
Release 2608.0: new ADMX products and StampAdmxRevision

### DIFF
--- a/.github/workflows/publish-psgallery.yml
+++ b/.github/workflows/publish-psgallery.yml
@@ -65,9 +65,24 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+          # Do not call Install-PackageProvider -Name NuGet on pwsh: the legacy
+          # bootstrap feed returns no match on hosted runners and fails the job.
+          # PowerShell 7 already ships a NuGet-capable PackageManagement stack
+          # (same pattern as ci.yml module installs).
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
-          Install-Module -Name PowerShellGet -MinimumVersion 2.2.5 -Scope CurrentUser -Force -AllowClobber
+
+          $installed = Get-Module -ListAvailable -Name PowerShellGet |
+            Sort-Object -Property Version -Descending |
+            Select-Object -First 1
+          if (-not $installed -or $installed.Version -lt [version]'2.2.5') {
+            Install-Module -Name PowerShellGet -MinimumVersion 2.2.5 -Scope CurrentUser -Force -AllowClobber -SkipPublisherCheck
+          } else {
+            Write-Host "PowerShellGet $($installed.Version) already meets minimum 2.2.5"
+          }
 
       - name: Skip if version already on PSGallery
         id: existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project uses a `YYMM.patch` release versioning scheme.
 - Added `-StampAdmxRevision` to stamp ADMX/ADML `revision` (and ADMX `minRequiredRevision` when `1.0`) from the product release Version as Major.Minor, so Intune shows a meaningful template version; files already above `1.0` are left unchanged
 - `-CleanPolicyStore` / `-CleanPolicyStoreOnly` now also remove `Microsoft-Windows-Geolocation-WLPAdm.admx` / `.adml` (superseded by `LocationProviderAdm`) and copy missing language ADMLs from `en-US` when available
 
+### Fixed
+
+- Fixed PSGallery publish workflow failing on `Install-PackageProvider -Name NuGet` under PowerShell 7 on GitHub Actions runners ([#87](https://github.com/msfreaks/EvergreenAdmx/issues/87))
+
 ## [2607.1] - 2026-07-29
 
 ### Added
@@ -47,7 +51,7 @@ and this project uses a `YYMM.patch` release versioning scheme.
 
 ### Added
 
-- Added `-CleanPolicyStore` to remove known obsolete or conflicting Admx/Adml from `-PolicyStore` after processing (WinStoreUI, legacy Office `*12*`–`*15*`, Adobe Classic 2017/2020, `ctxprofile*`, non-policy junk files/folders)
+- Added `-CleanPolicyStore` to remove known obsolete or conflicting Admx/Adml from `-PolicyStore` after processing (WinStoreUI, legacy Office `*12*`â€“`*15*`, Adobe Classic 2017/2020, `ctxprofile*`, non-policy junk files/folders)
 - Added `-CleanPolicyStoreOnly` to run Policy Store cleanup without downloading Admx files
 - Added Schannel ADMX support via [Crosse/SchannelGroupPolicy](https://github.com/Crosse/SchannelGroupPolicy) (`-Include 'Schannel'`)
 - Added Pester coverage for obsolete file patterns, `Initialize-PolicyStore`, and `Clear-ObsoleteAdmx` (including `-WhatIf`)
@@ -95,7 +99,7 @@ and this project uses a `YYMM.patch` release versioning scheme.
 - Removed `EvergreenAdmx.xml` sample Task Scheduler export in favor of `-CreateScheduledTask`
 - Removed Adobe Acrobat/Reader Classic 2017 and Classic 2020 tracks (EOL); Continuous track only
 - Removed Microsoft Desktop Optimization Pack ADMX support (extended support ended April 14, 2026)
-- Removed end-of-life Windows 10 feature versions `1903`–`21H1`; Windows 10 now supports `21H2` and `22H2` only
+- Removed end-of-life Windows 10 feature versions `1903`â€“`21H1`; Windows 10 now supports `21H2` and `22H2` only
 - Removed end-of-life Windows 11 feature versions `21H2` and `22H2`; Windows 11 now supports `23H2`, `24H2`, and `25H2` only
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses a `YYMM.patch` release versioning scheme.
 
-## [Unreleased]
+## [2608.0] 2026-08-01
 
 ### Added
 
@@ -26,7 +26,7 @@ and this project uses a `YYMM.patch` release versioning scheme.
 
 - Added GitHub Actions workflow to publish `EvergreenAdmx.ps1` to the PowerShell Gallery on release (`publish-psgallery.yml`)
 - Added tab-completion for `-Include` names and aliases via ArgumentCompleter
-- Added project logo (`assets/logo.webp`) and show it in README.md
+- Added project logo (`assets/logo.png`) and show it in README.md
 
 ### Changed
 
@@ -50,7 +50,6 @@ and this project uses a `YYMM.patch` release versioning scheme.
 - Added `-CleanPolicyStore` to remove known obsolete or conflicting Admx/Adml from `-PolicyStore` after processing (WinStoreUI, legacy Office `*12*`–`*15*`, Adobe Classic 2017/2020, `ctxprofile*`, non-policy junk files/folders)
 - Added `-CleanPolicyStoreOnly` to run Policy Store cleanup without downloading Admx files
 - Added Schannel ADMX support via [Crosse/SchannelGroupPolicy](https://github.com/Crosse/SchannelGroupPolicy) (`-Include 'Schannel'`)
-- Added sample thin orchestrator at `samples/Update-PolicyDefinitions.ps1`
 - Added Pester coverage for obsolete file patterns, `Initialize-PolicyStore`, and `Clear-ObsoleteAdmx` (including `-WhatIf`)
 - Added `-CreateScheduledTask` to create or update a weekly SYSTEM scheduled task (`EvergreenAdmx`, Sunday at 01:00) via `Register-ScheduledTask`; bound parameters are forwarded and the script exits after registration
 - Added Pester unit / Integration / Nightly suites under `tests/` and GitHub Actions workflows (`ci.yml`, `release-smoke.yml`, `nightly.yml`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project uses a `YYMM.patch` release versioning scheme.
 
 ### Added
 
+- Added Specops Authentication Client ADMX (on-prem + Entra ID templates)
+- Added WSL ADMX from [microsoft/WSL intune](https://github.com/microsoft/WSL/tree/master/intune) folder
+- Added Lenovo Dock Manager ADMX via policy_setup.exe (partially addresses #84; Commercial Vantage still tracked)
+- Added PDF-XChange ADMX
+- Added RealVNC Connect ADMX (Server + Viewer)
+- Added ABBYY FineReader PDF ADMX
+- Added Admin By Request ADMX
+- Added GoTo ADMX
 - Added `-StampAdmxRevision` to stamp ADMX/ADML `revision` (and ADMX `minRequiredRevision` when `1.0`) from the product release Version as Major.Minor, so Intune shows a meaningful template version; files already above `1.0` are left unchanged
 - `-CleanPolicyStore` / `-CleanPolicyStoreOnly` now also remove `Microsoft-Windows-Geolocation-WLPAdm.admx` / `.adml` (superseded by `LocationProviderAdm`) and copy missing language ADMLs from `en-US` when available
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses a `YYMM.patch` release versioning scheme.
 
+## [Unreleased]
+
+### Added
+
+- Added `-StampAdmxRevision` to stamp ADMX/ADML `revision` (and ADMX `minRequiredRevision` when `1.0`) from the product release Version as Major.Minor, so Intune shows a meaningful template version; files already above `1.0` are left unchanged
+- `-CleanPolicyStore` / `-CleanPolicyStoreOnly` now also remove `Microsoft-Windows-Geolocation-WLPAdm.admx` / `.adml` (superseded by `LocationProviderAdm`) and copy missing language ADMLs from `en-US` when available
+
 ## [2607.1] - 2026-07-29
 
 ### Added

--- a/EvergreenAdmx.ps1
+++ b/EvergreenAdmx.ps1
@@ -78,7 +78,7 @@
 .PARAMETER Include
     Array containing Admx products to include when checking for updates.
     Accepts canonical product names and short aliases (ProductKey, compact forms, and former names), e.g. "BISF" for "BIS-F", "Edge" for "Microsoft Edge".
-    Valid products are: "Custom Policy Store", "Windows 10", "Windows 11", "Windows 2022", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "Adobe DC", "BIS-F", "Citrix Workspace App", "Google Chrome", "Mozilla Firefox", "Mozilla Thunderbird", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Microsoft PowerToys", "Windows Terminal", "Brave Browser", "Microsoft Notepad", "Microsoft Clipchamp", "Microsoft Visual Studio", "Microsoft VS Code", "Slack", "1Password", "TeamViewer", "Security ADMX", "Schannel", "Dell Command Update", "Winget-AutoUpdate", "Winget-AutoUpdate-Intune", "PSAppDeployToolkit", "Devolutions Remote Desktop Manager", "Dropbox", "Foxit PDF", "LibreOffice", "HP Anyware".
+    Valid products are: "Custom Policy Store", "Windows 10", "Windows 11", "Windows 2022", "Windows 2025", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft FSLogix", "Adobe Acrobat", "Adobe Reader", "Adobe DC", "BIS-F", "Citrix Workspace App", "Google Chrome", "Mozilla Firefox", "Mozilla Thunderbird", "Zoom", "Zoom VDI", "Microsoft AVD", "Microsoft Winget", "Microsoft PowerToys", "Windows Terminal", "Brave Browser", "Microsoft Notepad", "Microsoft Clipchamp", "Microsoft Visual Studio", "Microsoft VS Code", "Slack", "1Password", "TeamViewer", "Security ADMX", "Schannel", "Dell Command Update", "Winget-AutoUpdate", "Winget-AutoUpdate-Intune", "PSAppDeployToolkit", "Devolutions Remote Desktop Manager", "Dropbox", "Foxit PDF", "LibreOffice", "HP Anyware", "Specops Authentication Client", "WSL", "Lenovo Dock Manager", "PDF-XChange", "RealVNC Connect", "ABBYY FineReader PDF", "Admin By Request", "GoTo".
     Defaults to "Windows 11", "Microsoft Edge", "Microsoft OneDrive", "Microsoft 365 Apps", "Microsoft Clipchamp", "Microsoft Notepad", "Microsoft Winget", "Windows Terminal".
 
 .PARAMETER PreferLocalOneDrive
@@ -287,6 +287,14 @@ function Get-EvergreenAdmxProductCatalog {
         [PSCustomObject]@{ Name = 'Foxit PDF'; Aliases = @('FoxitPDF', 'Foxit') }
         [PSCustomObject]@{ Name = 'LibreOffice'; Aliases = @('Collabora', 'CollaboraOffice') }
         [PSCustomObject]@{ Name = 'HP Anyware'; Aliases = @('HPAnyware', 'Anyware', 'PCoIP') }
+        [PSCustomObject]@{ Name = 'Specops Authentication Client'; Aliases = @('Specops', 'SpecopsClient', 'SpecopsAuthenticationClient', 'SPR', 'uReset', 'SpecopsPasswordReset') }
+        [PSCustomObject]@{ Name = 'WSL'; Aliases = @('Windows Subsystem for Linux', 'WindowsSubsystemForLinux') }
+        [PSCustomObject]@{ Name = 'Lenovo Dock Manager'; Aliases = @('DockManager', 'LenovoDockManager') }
+        [PSCustomObject]@{ Name = 'PDF-XChange'; Aliases = @('PDFXChange', 'PDF-X-Change', 'Tracker') }
+        [PSCustomObject]@{ Name = 'RealVNC Connect'; Aliases = @('RealVNC', 'VNC', 'RealVNCServer', 'RealVNCViewer') }
+        [PSCustomObject]@{ Name = 'ABBYY FineReader PDF'; Aliases = @('ABBYY', 'FineReader', 'FineReaderPDF', 'ABBYYFineReader') }
+        [PSCustomObject]@{ Name = 'Admin By Request'; Aliases = @('AdminByRequest', 'ABR') }
+        [PSCustomObject]@{ Name = 'GoTo'; Aliases = @('GoToConnect', 'GoTo App', 'GoToApp', 'LogMeIn GoTo') }
     )
 }
 
@@ -3764,6 +3772,639 @@ function Invoke-EvergreenAdmxHPAnyware {
     }
 }
 
+function Get-EvergreenAdmxSpecops {
+    <#
+    .SYNOPSIS
+        Returns latest Version and Uri for Specops Authentication Client ADMX files
+    #>
+
+    try {
+        $URI = 'https://download.specopssoft.com/Release/Client/Specops.Client.AdmxTemplates.zip'
+        $AzureAdURI = 'https://download.specopssoft.com/Release/Client/Specops.Client.AzureAdJoinedComputer.AdmxTemplates.zip'
+
+        $TempZip = Join-Path -Path $env:TEMP -ChildPath 'Specops.Client.AdmxTemplates.zip'
+        Invoke-FileDownload -Uri $URI -OutFile $TempZip -UseDefaultCredentials
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($TempZip)
+        try {
+            $entry = $zip.Entries | Where-Object { $_.Name -eq 'version.txt' } | Select-Object -First 1
+            if (-not $entry) {
+                throw 'version.txt was not found in Specops.Client.AdmxTemplates.zip'
+            }
+            $reader = New-Object System.IO.StreamReader($entry.Open())
+            try {
+                $Version = $reader.ReadToEnd().Trim()
+            } finally {
+                $reader.Close()
+            }
+        } finally {
+            $zip.Dispose()
+        }
+
+        Remove-Item -Path $TempZip -Force -ErrorAction SilentlyContinue
+
+        if ([string]::IsNullOrWhiteSpace($Version)) {
+            throw 'Unable to read Specops ADMX version from version.txt'
+        }
+
+        return @{ Version = $Version; URI = $URI; AzureAdURI = $AzureAdURI }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxSpecops {
+    <#
+    .SYNOPSIS
+        Process Specops Authentication Client Admx files (on-prem + Entra ID)
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxSpecops
+    $ProductName = 'Specops Authentication Client'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        $StagingFolder = Join-Path -Path $TempFolder -ChildPath 'staging'
+        try {
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            $null = New-Item -Path $StagingFolder -ItemType Directory -Force
+            $null = New-Item -Path (Join-Path $StagingFolder 'en-US') -ItemType Directory -Force
+
+            foreach ($item in @(
+                    @{ Name = 'Specops.Client.AdmxTemplates.zip'; URI = $Evergreen.URI }
+                    @{ Name = 'Specops.Client.AzureAdJoinedComputer.AdmxTemplates.zip'; URI = $Evergreen.AzureAdURI }
+                )) {
+                $OutFile = "$($WorkingDirectory)\downloads\$($item.Name)"
+                Write-Verbose "Downloading '$($item.URI)' to '$($OutFile)'"
+                Invoke-FileDownload -Uri $item.URI -OutFile $OutFile -UseDefaultCredentials
+
+                $ExtractPath = Join-Path -Path $TempFolder -ChildPath ([IO.Path]::GetFileNameWithoutExtension($item.Name))
+                Expand-Archive -Path $OutFile -DestinationPath $ExtractPath -Force
+
+                Get-ChildItem -Path $ExtractPath -Recurse -Filter '*.admx' -File | ForEach-Object {
+                    Copy-Item -Path $_.FullName -Destination $StagingFolder -Force
+                }
+                Get-ChildItem -Path $ExtractPath -Recurse -Filter '*.adml' -File | ForEach-Object {
+                    $langDir = $_.Directory.Name
+                    $destLang = Join-Path $StagingFolder $langDir
+                    if (-not (Test-Path -Path $destLang)) {
+                        $null = New-Item -Path $destLang -ItemType Directory -Force
+                    }
+                    Copy-Item -Path $_.FullName -Destination $destLang -Force
+                }
+            }
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $StagingFolder -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
+function Get-EvergreenAdmxWSL {
+    <#
+    .SYNOPSIS
+        Returns latest Version (commit SHA) for Microsoft WSL Intune ADMX files
+    #>
+
+    try {
+        $commits = Invoke-RestMethod -Uri 'https://api.github.com/repos/microsoft/WSL/commits?path=intune&per_page=1' -Headers @{ 'User-Agent' = 'EvergreenAdmx' } -UseBasicParsing
+        $Version = $commits[0].sha.Substring(0, 7)
+        return @{ Version = $Version; URI = 'https://api.github.com/repos/microsoft/WSL/contents/intune?ref=master' }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxWSL {
+    <#
+    .SYNOPSIS
+        Process Microsoft WSL Intune Admx files from GitHub
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxWSL
+    $ProductName = 'WSL'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or $Evergreen.Version -ne $Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        $StagingFolder = Join-Path -Path $TempFolder -ChildPath 'staging'
+        try {
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            $null = New-Item -Path $StagingFolder -ItemType Directory -Force
+
+            function Save-WSLGitHubContents {
+                param(
+                    [string]$ApiUri,
+                    [string]$TargetRoot
+                )
+
+                $entries = Invoke-RestMethod -Uri $ApiUri -Headers @{ 'User-Agent' = 'EvergreenAdmx' } -UseBasicParsing
+                foreach ($entry in $entries) {
+                    if ($entry.type -eq 'dir') {
+                        $subDir = Join-Path -Path $TargetRoot -ChildPath $entry.name
+                        if (-not (Test-Path -Path $subDir)) {
+                            $null = New-Item -Path $subDir -ItemType Directory -Force
+                        }
+                        Save-WSLGitHubContents -ApiUri $entry.url -TargetRoot $subDir
+                    } elseif ($entry.type -eq 'file' -and $entry.name -match '\.(admx|adml)$') {
+                        $outFile = Join-Path -Path $TargetRoot -ChildPath $entry.name
+                        Write-Verbose "Downloading '$($entry.download_url)' to '$($outFile)'"
+                        Invoke-FileDownload -Uri $entry.download_url -OutFile $outFile -UseDefaultCredentials
+                    }
+                }
+            }
+
+            Save-WSLGitHubContents -ApiUri $Evergreen.URI -TargetRoot $StagingFolder
+
+            if (-not (Get-ChildItem -Path $StagingFolder -Filter 'WSL.admx' -File -ErrorAction SilentlyContinue)) {
+                throw 'WSL.admx was not found in the microsoft/WSL intune folder.'
+            }
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $StagingFolder -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
+function Get-EvergreenAdmxLenovoDockManager {
+    <#
+    .SYNOPSIS
+        Returns latest Version and Uri for Lenovo Dock Manager ADMX files
+    #>
+
+    try {
+        $URI = 'https://download.lenovo.com/consumer/options/policy_setup.exe'
+        $TempExe = Join-Path -Path $env:TEMP -ChildPath 'policy_setup.exe'
+        Invoke-FileDownload -Uri $URI -OutFile $TempExe -UseDefaultCredentials
+
+        $info = (Get-Item -LiteralPath $TempExe).VersionInfo
+        $Version = $null
+        if ($info.ProductName -match 'Package\s+(\d+(?:\.\d+)+)') {
+            $Version = $Matches[1]
+        } elseif (-not [string]::IsNullOrWhiteSpace($info.FileVersion)) {
+            $Version = ($info.FileVersion).Trim()
+        }
+
+        Remove-Item -Path $TempExe -Force -ErrorAction SilentlyContinue
+
+        if ([string]::IsNullOrWhiteSpace($Version)) {
+            throw 'Unable to determine Lenovo Dock Manager ADMX package version from policy_setup.exe'
+        }
+
+        return @{ Version = $Version; URI = $URI }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxLenovoDockManager {
+    <#
+    .SYNOPSIS
+        Process Lenovo Dock Manager Admx files from policy_setup.exe
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxLenovoDockManager
+    $ProductName = 'Lenovo Dock Manager'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $OutFile = "$($WorkingDirectory)\downloads\policy_setup.exe"
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        try {
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-FileDownload -Uri $Evergreen.URI -OutFile $OutFile -UseDefaultCredentials
+
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            $null = New-Item -Path $TempFolder -ItemType Directory -Force
+
+            Write-Verbose "Extracting Inno Setup package to '$($TempFolder)'"
+            $proc = Start-Process -FilePath $OutFile -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/DIR=`"$TempFolder`"") -Wait -PassThru
+            if ($proc.ExitCode -ne 0 -and $null -ne $proc.ExitCode) {
+                Write-Verbose "Inno extract exit code: $($proc.ExitCode)"
+            }
+
+            $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter '*.admx' -File -ErrorAction SilentlyContinue |
+                Select-Object -First 1).DirectoryName
+            if (-not $SourceAdmx) {
+                $SourceAdmx = (Get-ChildItem -Path "$env:SystemRoot\PolicyDefinitions" -Filter '*Dock*' -File -ErrorAction SilentlyContinue |
+                    Select-Object -First 1).DirectoryName
+            }
+            if (-not $SourceAdmx) {
+                throw 'Lenovo Dock Manager ADMX files were not found after extracting policy_setup.exe'
+            }
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force -ErrorAction SilentlyContinue
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
+function Get-EvergreenAdmxPDFXChange {
+    <#
+    .SYNOPSIS
+        Returns latest Version and Uri for PDF-XChange ADMX files
+    #>
+
+    try {
+        $URI = 'https://www.pdf-xchange.com/Tracker%5FAD%5FAdministrativeTemplates.zip'
+        $LastModifiedDate = (Resolve-Uri -Uri $URI).LastModified
+        [version]$Version = $LastModifiedDate.ToString('yyyy.MM.dd')
+        return @{ Version = $Version.ToString(); URI = $URI }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxPDFXChange {
+    <#
+    .SYNOPSIS
+        Process PDF-XChange Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxPDFXChange
+    $ProductName = 'PDF-XChange'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $OutFile = "$($WorkingDirectory)\downloads\Tracker_AD_AdministrativeTemplates.zip"
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        try {
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-FileDownload -Uri $Evergreen.URI -OutFile $OutFile -UseDefaultCredentials
+
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            Expand-Archive -Path $OutFile -DestinationPath $TempFolder -Force
+
+            $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'PDFXEditor.admx' | Select-Object -First 1).DirectoryName
+            if (-not $SourceAdmx) {
+                throw 'PDFXEditor.admx was not found in the PDF-XChange administrative templates zip.'
+            }
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
+function Get-EvergreenAdmxRealVNC {
+    <#
+    .SYNOPSIS
+        Returns latest Version and Uri for RealVNC Connect Server/Viewer ADMX files
+    #>
+
+    try {
+        $ServerURI = 'https://downloads.realvnc.com/download/file/policy.files/RealVNC-server-admx-templates-Latest.zip'
+        $ViewerURI = 'https://downloads.realvnc.com/download/file/policy.files/RealVNC-viewer-admx-templates-Latest.zip'
+
+        $serverLm = (Resolve-Uri -Uri $ServerURI).LastModified
+        $viewerLm = (Resolve-Uri -Uri $ViewerURI).LastModified
+        $Latest = if ($serverLm -ge $viewerLm) { $serverLm } else { $viewerLm }
+        [version]$Version = $Latest.ToString('yyyy.MM.dd')
+
+        return @{ Version = $Version.ToString(); URI = $ServerURI; ViewerURI = $ViewerURI }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxRealVNC {
+    <#
+    .SYNOPSIS
+        Process RealVNC Connect Server and Viewer Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxRealVNC
+    $ProductName = 'RealVNC Connect'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        $StagingFolder = Join-Path -Path $TempFolder -ChildPath 'staging'
+        try {
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            $null = New-Item -Path $StagingFolder -ItemType Directory -Force
+            $null = New-Item -Path (Join-Path $StagingFolder 'en-US') -ItemType Directory -Force
+
+            # Viewer first, then Server so newer shared realvnc.admx/adml win
+            foreach ($item in @(
+                    @{ Name = 'RealVNC-viewer-admx-templates-Latest.zip'; URI = $Evergreen.ViewerURI }
+                    @{ Name = 'RealVNC-server-admx-templates-Latest.zip'; URI = $Evergreen.URI }
+                )) {
+                $OutFile = "$($WorkingDirectory)\downloads\$($item.Name)"
+                Write-Verbose "Downloading '$($item.URI)' to '$($OutFile)'"
+                Invoke-FileDownload -Uri $item.URI -OutFile $OutFile -UseDefaultCredentials
+
+                $ExtractPath = Join-Path -Path $TempFolder -ChildPath ([IO.Path]::GetFileNameWithoutExtension($item.Name))
+                Expand-Archive -Path $OutFile -DestinationPath $ExtractPath -Force
+
+                $AdmxRoot = Join-Path -Path $ExtractPath -ChildPath 'admx'
+                if (-not (Test-Path -Path $AdmxRoot)) {
+                    $AdmxRoot = $ExtractPath
+                }
+
+                Get-ChildItem -Path $AdmxRoot -Filter '*.admx' -File | ForEach-Object {
+                    Copy-Item -Path $_.FullName -Destination $StagingFolder -Force
+                }
+                Get-ChildItem -Path $AdmxRoot -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+                    $destLang = Join-Path $StagingFolder $_.Name
+                    if (-not (Test-Path -Path $destLang)) {
+                        $null = New-Item -Path $destLang -ItemType Directory -Force
+                    }
+                    Get-ChildItem -Path $_.FullName -Filter '*.adml' -File | ForEach-Object {
+                        Copy-Item -Path $_.FullName -Destination $destLang -Force
+                    }
+                }
+            }
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $StagingFolder -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
+function Get-EvergreenAdmxABBYYFineReader {
+    <#
+    .SYNOPSIS
+        Returns latest Version and Uri for ABBYY FineReader PDF ADMX files
+    #>
+
+    try {
+        $pageUrl = 'https://help.abbyy.com/en-us/finereader/16/admin_guide/gpo_domain/'
+        $admxUri = 'https://support.abbyy.com/hc/en-us/article_attachments/8277004669075/FineReader16.admx'
+        $admlUri = 'https://support.abbyy.com/hc/en-us/article_attachments/8277017934739/FineReader16.adml'
+
+        try {
+            $web = (Invoke-WebRequest -UseDefaultCredentials -Uri $pageUrl -UseBasicParsing).Content
+            $admxMatch = [regex]::Match($web, 'https://support\.abbyy\.com/hc/[^"''\s<>]+FineReader16\.admx')
+            $admlMatch = [regex]::Match($web, 'https://support\.abbyy\.com/hc/[^"''\s<>]+FineReader16\.adml')
+            if ($admxMatch.Success) { $admxUri = $admxMatch.Value }
+            if ($admlMatch.Success) { $admlUri = $admlMatch.Value }
+        } catch {
+            Write-Verbose "ABBYY page scrape failed; using known attachment URLs: $($_.Exception.Message)"
+        }
+
+        $LastModifiedDate = (Resolve-Uri -Uri $admxUri).LastModified
+        [version]$Version = $LastModifiedDate.ToString('yyyy.MM.dd')
+        return @{ Version = $Version.ToString(); URI = $admxUri; AdmlURI = $admlUri }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxABBYYFineReader {
+    <#
+    .SYNOPSIS
+        Process ABBYY FineReader PDF Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxABBYYFineReader
+    $ProductName = 'ABBYY FineReader PDF'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        $StagingFolder = Join-Path -Path $TempFolder -ChildPath 'staging'
+        try {
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            $null = New-Item -Path (Join-Path $StagingFolder 'en-US') -ItemType Directory -Force
+
+            $OutAdmx = "$($WorkingDirectory)\downloads\FineReader16.admx"
+            $OutAdml = "$($WorkingDirectory)\downloads\FineReader16.adml"
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutAdmx)'"
+            Invoke-FileDownload -Uri $Evergreen.URI -OutFile $OutAdmx -UseDefaultCredentials
+            Write-Verbose "Downloading '$($Evergreen.AdmlURI)' to '$($OutAdml)'"
+            Invoke-FileDownload -Uri $Evergreen.AdmlURI -OutFile $OutAdml -UseDefaultCredentials
+
+            Copy-Item -Path $OutAdmx -Destination $StagingFolder -Force
+            Copy-Item -Path $OutAdml -Destination (Join-Path $StagingFolder 'en-US') -Force
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $StagingFolder -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
+function Get-EvergreenAdmxAdminByRequest {
+    <#
+    .SYNOPSIS
+        Returns latest Version (content hash) and Uri for Admin By Request ADMX files
+    #>
+
+    try {
+        $URI = 'https://www.adminbyrequest.com/ADMX'
+        $TempZip = Join-Path -Path $env:TEMP -ChildPath 'AdminByRequest-Admx.zip'
+        Invoke-FileDownload -Uri $URI -OutFile $TempZip -UseDefaultCredentials
+
+        $hash = (Get-FileHash -Path $TempZip -Algorithm SHA256).Hash.ToLowerInvariant()
+        $Version = $hash.Substring(0, 12)
+        Remove-Item -Path $TempZip -Force -ErrorAction SilentlyContinue
+
+        return @{ Version = $Version; URI = $URI }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxAdminByRequest {
+    <#
+    .SYNOPSIS
+        Process Admin By Request Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxAdminByRequest
+    $ProductName = 'Admin By Request'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or $Evergreen.Version -ne $Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $OutFile = "$($WorkingDirectory)\downloads\AdminByRequest-Admx.zip"
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        try {
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-FileDownload -Uri $Evergreen.URI -OutFile $OutFile -UseDefaultCredentials
+
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            Expand-Archive -Path $OutFile -DestinationPath $TempFolder -Force
+
+            $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'AdminByRequest.admx' | Select-Object -First 1).DirectoryName
+            if (-not $SourceAdmx) {
+                throw 'AdminByRequest.admx was not found in the Admin By Request ADMX zip.'
+            }
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
+function Get-EvergreenAdmxGoTo {
+    <#
+    .SYNOPSIS
+        Returns latest Version and Uri for GoTo app ADMX files
+    #>
+
+    try {
+        $URI = 'https://goto-desktop.goto.com/GoToAppAdministrativeTemplates.zip'
+        $LastModifiedDate = (Resolve-Uri -Uri $URI).LastModified
+        [version]$Version = $LastModifiedDate.ToString('yyyy.MM.dd')
+        return @{ Version = $Version.ToString(); URI = $URI }
+    } catch {
+        Throw $_
+    }
+}
+
+function Invoke-EvergreenAdmxGoTo {
+    <#
+    .SYNOPSIS
+        Process GoTo app Admx files
+    #>
+
+    param(
+        [string]$Version,
+        [string]$PolicyStore = $null,
+        [string[]]$Languages = $null
+    )
+
+    $Evergreen = Get-EvergreenAdmxGoTo
+    $ProductName = 'GoTo'
+    $ProductFolder = ''; if ($UseProductFolders) { $ProductFolder = "\$($ProductName)" }
+
+    if (-not $Version -or [version]$Evergreen.Version -gt [version]$Version) {
+        Write-Verbose "Found new version $($Evergreen.Version) for '$($ProductName)'"
+
+        $OutFile = "$($WorkingDirectory)\downloads\GoToAppAdministrativeTemplates.zip"
+        $TempFolder = "$($env:TEMP)\$($ProductName)"
+        try {
+            Write-Verbose "Downloading '$($Evergreen.URI)' to '$($OutFile)'"
+            Invoke-FileDownload -Uri $Evergreen.URI -OutFile $OutFile -UseDefaultCredentials
+
+            if (Test-Path -Path $TempFolder) { Remove-Item -Path $TempFolder -Recurse -Force }
+            Expand-Archive -Path $OutFile -DestinationPath $TempFolder -Force
+
+            $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'GoTo.admx' | Select-Object -First 1).DirectoryName
+            if (-not $SourceAdmx) {
+                throw 'GoTo.admx was not found in GoToAppAdministrativeTemplates.zip'
+            }
+
+            $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
+
+            Remove-Item -Path $TempFolder -Recurse -Force
+            return $Evergreen
+        } catch {
+            Throw $_
+        }
+    } else {
+        return $null
+    }
+}
+
 # Download functions
 function Invoke-EvergreenAdmxWindows {
     <#
@@ -5352,6 +5993,78 @@ if ($Include -notcontains 'HP Anyware') {
     Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'HPAnyware' -AdmxData $admx
 }
 
+
+# Specops Authentication Client
+if ($Include -notcontains 'Specops Authentication Client') {
+    Write-Verbose "`nSkipping Specops Authentication Client"
+} else {
+    Write-Verbose "`nProcessing Admx files for Specops Authentication Client"
+    $admx = Invoke-EvergreenAdmxSpecops -Version $AdmxVersions.SpecopsAuthenticationClient.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'SpecopsAuthenticationClient' -AdmxData $admx
+}
+
+# WSL
+if ($Include -notcontains 'WSL') {
+    Write-Verbose "`nSkipping WSL"
+} else {
+    Write-Verbose "`nProcessing Admx files for WSL"
+    $admx = Invoke-EvergreenAdmxWSL -Version $AdmxVersions.WSL.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'WSL' -AdmxData $admx
+}
+
+# Lenovo Dock Manager
+if ($Include -notcontains 'Lenovo Dock Manager') {
+    Write-Verbose "`nSkipping Lenovo Dock Manager"
+} else {
+    Write-Verbose "`nProcessing Admx files for Lenovo Dock Manager"
+    $admx = Invoke-EvergreenAdmxLenovoDockManager -Version $AdmxVersions.LenovoDockManager.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'LenovoDockManager' -AdmxData $admx
+}
+
+# PDF-XChange
+if ($Include -notcontains 'PDF-XChange') {
+    Write-Verbose "`nSkipping PDF-XChange"
+} else {
+    Write-Verbose "`nProcessing Admx files for PDF-XChange"
+    $admx = Invoke-EvergreenAdmxPDFXChange -Version $AdmxVersions.PDFXChange.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'PDFXChange' -AdmxData $admx
+}
+
+# RealVNC Connect
+if ($Include -notcontains 'RealVNC Connect') {
+    Write-Verbose "`nSkipping RealVNC Connect"
+} else {
+    Write-Verbose "`nProcessing Admx files for RealVNC Connect"
+    $admx = Invoke-EvergreenAdmxRealVNC -Version $AdmxVersions.RealVNCConnect.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'RealVNCConnect' -AdmxData $admx
+}
+
+# ABBYY FineReader PDF
+if ($Include -notcontains 'ABBYY FineReader PDF') {
+    Write-Verbose "`nSkipping ABBYY FineReader PDF"
+} else {
+    Write-Verbose "`nProcessing Admx files for ABBYY FineReader PDF"
+    $admx = Invoke-EvergreenAdmxABBYYFineReader -Version $AdmxVersions.ABBYYFineReaderPDF.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'ABBYYFineReaderPDF' -AdmxData $admx
+}
+
+# Admin By Request
+if ($Include -notcontains 'Admin By Request') {
+    Write-Verbose "`nSkipping Admin By Request"
+} else {
+    Write-Verbose "`nProcessing Admx files for Admin By Request"
+    $admx = Invoke-EvergreenAdmxAdminByRequest -Version $AdmxVersions.AdminByRequest.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'AdminByRequest' -AdmxData $admx
+}
+
+# GoTo
+if ($Include -notcontains 'GoTo') {
+    Write-Verbose "`nSkipping GoTo"
+} else {
+    Write-Verbose "`nProcessing Admx files for GoTo"
+    $admx = Invoke-EvergreenAdmxGoTo -Version $AdmxVersions.GoTo.Version -PolicyStore $PolicyStore -Languages $Languages
+    Update-AdmxVersion -AdmxVersions ([ref]$AdmxVersions) -ProductKey 'GoTo' -AdmxData $admx
+}
 if ($CleanPolicyStore -and $PolicyStoreSpecified) {
     Write-Verbose "`nCleaning obsolete Admx files from Policy Store '$($PolicyStore)'"
     $null = Clear-ObsoleteAdmx -PolicyStore $PolicyStore -Languages $Languages

--- a/EvergreenAdmx.ps1
+++ b/EvergreenAdmx.ps1
@@ -87,17 +87,24 @@
 
 .PARAMETER CleanPolicyStore
     After processing, remove known obsolete or conflicting Admx/Adml files from -PolicyStore
-    (WinStoreUI, legacy Office *12-*15, Adobe Classic 2017/2020, ctxprofile*, CitrixBase, non-policy junk).
+    (WinStoreUI, Microsoft-Windows-Geolocation-WLPAdm, legacy Office *12-*15, Adobe Classic 2017/2020,
+    ctxprofile*, CitrixBase, non-policy junk) and copy missing language ADMLs from en-US when available.
     Requires -PolicyStore. Supports -WhatIf.
 
 .PARAMETER CleanPolicyStoreOnly
-    Skip downloads and only clean -PolicyStore using the same obsolete-file rules as -CleanPolicyStore.
+    Skip downloads and only clean -PolicyStore using the same obsolete-file and ADML-repair rules as -CleanPolicyStore.
     Requires -PolicyStore. Supports -WhatIf.
 
 .PARAMETER CreateScheduledTask
     Creates or updates a weekly Windows Scheduled Task named EvergreenAdmx that runs this script
     as SYSTEM with highest privileges (Sunday at 01:00). Bound parameters are forwarded to the
     task action except CreateScheduledTask. The script exits after registering the task and does not download Admx files in that run.
+
+.PARAMETER StampAdmxRevision
+    When set, stamps ADMX/ADML revision attributes from the product release Version (Major.Minor
+    ADMX versionString form) so Intune Imported Administrative Templates show a meaningful Version.
+    Only attributes currently set to 1.0 are updated; higher vendor revisions are left unchanged.
+    Also updates ADMX resources minRequiredRevision when it is 1.0.
 
 .EXAMPLE
     .\EvergreenAdmx.ps1
@@ -127,12 +134,12 @@
 .EXAMPLE
     .\EvergreenAdmx.ps1 -PolicyStore "\\contoso.com\SYSVOL\contoso.com\Policies\PolicyDefinitions" -Include @('Windows 11', 'Microsoft Edge') -CleanPolicyStore
 
-    Downloads the specified products, copies them to the Central Policy Store (creating it if missing), then removes known obsolete Admx files.
+    Downloads the specified products, copies them to the Central Policy Store (creating it if missing), then removes known obsolete Admx files and repairs missing ADMLs.
 
 .EXAMPLE
     .\EvergreenAdmx.ps1 -PolicyStore "\\contoso.com\SYSVOL\contoso.com\Policies\PolicyDefinitions" -CleanPolicyStoreOnly -WhatIf
 
-    Shows which obsolete Admx/Adml files would be removed from the Central Policy Store without deleting anything.
+    Shows which obsolete Admx/Adml files would be removed (and which missing ADMLs would be copied from en-US) without changing the store.
 
 .LINK
     https://github.com/msfreaks/EvergreenAdmx
@@ -174,6 +181,8 @@ param(
     [switch] $CleanPolicyStoreOnly,
     [Parameter(Mandatory = $false)]
     [switch] $CreateScheduledTask,
+    [Parameter(Mandatory = $false)]
+    [switch] $StampAdmxRevision,
     [ArgumentCompleter({
             param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
             $null = $commandName, $parameterName, $fakeBoundParameters
@@ -422,6 +431,7 @@ Write-Verbose "PreferLocalOneDrive:`t'$($PreferLocalOneDrive)'"
 Write-Verbose "CleanPolicyStore:`t'$($CleanPolicyStore)'"
 Write-Verbose "CleanPolicyStoreOnly:`t'$($CleanPolicyStoreOnly)'"
 Write-Verbose "CreateScheduledTask:`t'$($CreateScheduledTask)'"
+Write-Verbose "StampAdmxRevision:`t'$($StampAdmxRevision)'"
 
 function New-EvergreenAdmxTaskArgumentList {
     <#
@@ -1002,6 +1012,175 @@ function Invoke-FileDownload {
     }
 }
 
+function ConvertTo-AdmxRevisionString {
+    <#
+    .SYNOPSIS
+        Converts a product release Version to an ADMX versionString (Major.Minor).
+    #>
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    $normalized = $Version.Trim()
+    if ($normalized -match '^v(?<ver>.+)$') {
+        $normalized = $Matches['ver']
+    }
+
+    try {
+        $parsed = [version]$normalized
+        return ('{0}.{1}' -f $parsed.Major, $parsed.Minor)
+    } catch {
+        Write-Warning "Unable to convert '$Version' to ADMX revision (Major.Minor)."
+        return $null
+    }
+}
+
+function Test-AdmxRevisionIsOnePointZero {
+    <#
+    .SYNOPSIS
+        Returns $true when an ADMX/ADML revision attribute is exactly 1.0.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+    try {
+        return ([version]$Value) -eq ([version]'1.0')
+    } catch {
+        return ($Value -eq '1.0')
+    }
+}
+
+function Save-AdmxXmlDocument {
+    <#
+    .SYNOPSIS
+        Saves an XmlDocument as UTF-8 without BOM.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument]$Xml,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath
+    )
+
+    $encoding = New-Object System.Text.UTF8Encoding $false
+    $settings = New-Object System.Xml.XmlWriterSettings
+    $settings.Encoding = $encoding
+    # PreserveWhitespace on load; avoid re-indenting the document on save
+    $settings.Indent = $false
+    $settings.OmitXmlDeclaration = $false
+    $writer = [System.Xml.XmlWriter]::Create($FilePath, $settings)
+    try {
+        $Xml.Save($writer)
+    } finally {
+        $writer.Dispose()
+    }
+}
+
+function Set-AdmxRevision {
+    <#
+    .SYNOPSIS
+        Stamps ADMX/ADML revision attributes when the current value is exactly 1.0.
+
+    .DESCRIPTION
+        Updates policyDefinitions/@revision, resources/@minRequiredRevision (ADMX), and
+        policyDefinitionResources/@revision (ADML) only when each attribute is currently 1.0.
+        Higher vendor revisions are left unchanged.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Revision
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Write-Verbose "Set-AdmxRevision: path '$Path' does not exist"
+        return
+    }
+
+    $admxFiles = @(Get-ChildItem -LiteralPath $Path -Filter '*.admx' -File -ErrorAction SilentlyContinue)
+    $admlFiles = @(Get-ChildItem -LiteralPath $Path -Filter '*.adml' -File -Recurse -ErrorAction SilentlyContinue)
+
+    foreach ($file in $admxFiles) {
+        if (-not $PSCmdlet.ShouldProcess($file.FullName, "Stamp ADMX revision to $Revision when 1.0")) { continue }
+        try {
+            $xml = New-Object System.Xml.XmlDocument
+            $xml.PreserveWhitespace = $true
+            $xml.Load($file.FullName)
+            $root = $xml.DocumentElement
+            if ($null -eq $root -or $root.LocalName -ne 'policyDefinitions') {
+                Write-Verbose "Skipping '$($file.Name)': root is not policyDefinitions"
+                continue
+            }
+
+            $changed = $false
+            $currentRevision = $root.GetAttribute('revision')
+            if (Test-AdmxRevisionIsOnePointZero -Value $currentRevision) {
+                $root.SetAttribute('revision', $Revision)
+                $changed = $true
+                Write-Verbose "Stamped '$($file.Name)' revision $currentRevision -> $Revision"
+            } else {
+                Write-Verbose "Skipped '$($file.Name)' revision '$currentRevision' (not 1.0)"
+            }
+
+            $resources = $root.SelectSingleNode('*[local-name()="resources"]')
+            if ($resources) {
+                $minRequired = $resources.GetAttribute('minRequiredRevision')
+                if (Test-AdmxRevisionIsOnePointZero -Value $minRequired) {
+                    $resources.SetAttribute('minRequiredRevision', $Revision)
+                    $changed = $true
+                    Write-Verbose "Stamped '$($file.Name)' minRequiredRevision $minRequired -> $Revision"
+                } else {
+                    Write-Verbose "Skipped '$($file.Name)' minRequiredRevision '$minRequired' (not 1.0)"
+                }
+            }
+
+            if ($changed) {
+                Save-AdmxXmlDocument -Xml $xml -FilePath $file.FullName
+            }
+        } catch {
+            Write-Warning "Failed to stamp ADMX revision on '$($file.FullName)': $_"
+        }
+    }
+
+    foreach ($file in $admlFiles) {
+        if (-not $PSCmdlet.ShouldProcess($file.FullName, "Stamp ADML revision to $Revision when 1.0")) { continue }
+        try {
+            $xml = New-Object System.Xml.XmlDocument
+            $xml.PreserveWhitespace = $true
+            $xml.Load($file.FullName)
+            $root = $xml.DocumentElement
+            if ($null -eq $root -or $root.LocalName -ne 'policyDefinitionResources') {
+                Write-Verbose "Skipping '$($file.Name)': root is not policyDefinitionResources"
+                continue
+            }
+
+            $currentRevision = $root.GetAttribute('revision')
+            if (Test-AdmxRevisionIsOnePointZero -Value $currentRevision) {
+                $root.SetAttribute('revision', $Revision)
+                Write-Verbose "Stamped '$($file.Name)' revision $currentRevision -> $Revision"
+                Save-AdmxXmlDocument -Xml $xml -FilePath $file.FullName
+            } else {
+                Write-Verbose "Skipped '$($file.Name)' revision '$currentRevision' (not 1.0)"
+            }
+        } catch {
+            Write-Warning "Failed to stamp ADML revision on '$($file.FullName)': $_"
+        }
+    }
+}
+
 function Copy-Admx {
     param (
         [string]$SourceFolder,
@@ -1009,7 +1188,8 @@ function Copy-Admx {
         [string]$PolicyStore = $null,
         [string]$ProductName,
         [switch]$Quiet,
-        [string[]]$Languages = $null
+        [string[]]$Languages = $null,
+        [string]$Revision = $null
     )
     if (-not (Test-Path -Path "$($TargetFolder)")) { $null = (New-Item -Path "$($TargetFolder)" -ItemType Directory -Force) }
     if (-not $Languages -or $Languages -eq '') { $Languages = @('en-US') }
@@ -1038,6 +1218,17 @@ function Copy-Admx {
             Copy-Item -Path "$($SourceFolder)\$($language)\*.adml" -Destination "$($PolicyStore)$($language)" -Force
         }
     }
+
+    if ($Revision) {
+        $normalizedRevision = ConvertTo-AdmxRevisionString -Version $Revision
+        if ($normalizedRevision) {
+            Write-Verbose "Stamping ADMX/ADML revision '$normalizedRevision' for '$ProductName'"
+            Set-AdmxRevision -Path $TargetFolder -Revision $normalizedRevision
+            if ($PolicyStore) {
+                Set-AdmxRevision -Path $PolicyStore -Revision $normalizedRevision
+            }
+        }
+    }
 }
 
 function Get-EvergreenAdmxObsoleteFilePattern {
@@ -1052,6 +1243,8 @@ function Get-EvergreenAdmxObsoleteFilePattern {
     return @(
         'WinStoreUI.admx'
         'WinStoreUI.adml'
+        'Microsoft-Windows-Geolocation-WLPAdm.admx'
+        'Microsoft-Windows-Geolocation-WLPAdm.adml'
         '*12*.admx'
         '*12*.adml'
         '*13*.admx'
@@ -1112,7 +1305,8 @@ function Initialize-PolicyStore {
 function Clear-ObsoleteAdmx {
     <#
     .SYNOPSIS
-        Removes known obsolete or conflicting Admx/Adml files from a Policy Store.
+        Removes known obsolete or conflicting Admx/Adml files from a Policy Store,
+        and copies missing language ADMLs from en-US when available.
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     [OutputType([System.Object[]])]
@@ -1170,6 +1364,55 @@ function Clear-ObsoleteAdmx {
             Write-Verbose "Removing non-language folder '$($folder.FullName)'"
             Remove-Item -LiteralPath $folder.FullName -Recurse -Force
             $removed.Add($folder.FullName)
+        }
+    }
+
+    # Repair missing ADMLs: copy en-US into requested language folders when the ADMX has no matching ADML
+    $enUsFolder = Join-Path -Path $store -ChildPath 'en-US'
+    $admxFiles = @(
+        Get-ChildItem -LiteralPath $store -Filter '*.admx' -File -ErrorAction SilentlyContinue |
+            Where-Object {
+                $name = $_.Name
+                -not ($patterns | Where-Object { $name -like $_ })
+            }
+    )
+    $languageFolders = @(
+        Get-ChildItem -LiteralPath $store -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match $languagePattern -or ($Languages -contains $_.Name) }
+    )
+
+    foreach ($admx in $admxFiles) {
+        $admlName = "$($admx.BaseName).adml"
+        $enUsAdml = Join-Path -Path $enUsFolder -ChildPath $admlName
+
+        foreach ($language in $Languages) {
+            if ($language -eq 'en-US') { continue }
+            $languageFolder = Join-Path -Path $store -ChildPath $language
+            $targetAdml = Join-Path -Path $languageFolder -ChildPath $admlName
+            if (Test-Path -LiteralPath $targetAdml) { continue }
+            if (-not (Test-Path -LiteralPath $enUsAdml)) { continue }
+
+            if ($PSCmdlet.ShouldProcess($targetAdml, "Copy missing ADML from en-US for language '$language'")) {
+                if (-not (Test-Path -LiteralPath $languageFolder)) {
+                    $null = New-Item -Path $languageFolder -ItemType Directory -Force
+                }
+                Write-Warning "Missing ADML for '$($admx.Name)' in '$language'; copying from en-US."
+                Copy-Item -LiteralPath $enUsAdml -Destination $targetAdml -Force
+            }
+        }
+
+        $hasAnyAdml = $false
+        foreach ($folder in $languageFolders) {
+            if (Test-Path -LiteralPath (Join-Path -Path $folder.FullName -ChildPath $admlName)) {
+                $hasAnyAdml = $true
+                break
+            }
+        }
+        if (-not $hasAnyAdml -and (Test-Path -LiteralPath $enUsAdml)) {
+            $hasAnyAdml = $true
+        }
+        if (-not $hasAnyAdml) {
+            Write-Warning "No ADML found for '$($admx.Name)' in any language folder under '$store'."
         }
     }
 
@@ -1784,7 +2027,7 @@ function Invoke-EvergreenAdmxNotepad {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'WindowsNotepad.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -1869,7 +2112,7 @@ function Invoke-EvergreenAdmxClipchamp {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter '*.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -1957,7 +2200,7 @@ function Invoke-EvergreenAdmxVisualStudio {
             # copy
             $SourceAdmx = "$($TempFolder)\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2042,7 +2285,7 @@ function Invoke-EvergreenAdmxVSCode {
 
             # copy
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2133,7 +2376,7 @@ function Invoke-EvergreenAdmx1Password {
             # copy (zip layout: 1Password Policies\PolicyDefinitions)
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter '1Password.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2221,7 +2464,7 @@ function Invoke-EvergreenAdmxSlack {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'slack.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2301,7 +2544,7 @@ function Invoke-EvergreenAdmxTeamViewer {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'TeamViewer.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2390,7 +2633,7 @@ function Invoke-EvergreenAdmxAdobeDC {
 
             # copy
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2470,7 +2713,7 @@ function Invoke-EvergreenAdmxSecurityAdmx {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Directory | Select-Object -First 1).FullName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2544,7 +2787,7 @@ function Invoke-EvergreenAdmxSchannel {
             }
 
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force
             return $Evergreen
@@ -2673,7 +2916,7 @@ function Invoke-EvergreenAdmxDellCommandUpdate {
 
             # copy
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force -ErrorAction SilentlyContinue
@@ -2753,7 +2996,7 @@ function Invoke-EvergreenAdmxWingetAutoUpdate {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'WAU.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2833,7 +3076,7 @@ function Invoke-EvergreenAdmxWingetAutoUpdateIntune {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'WinGet-AutoUpdate-Configurator.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2913,7 +3156,7 @@ function Invoke-EvergreenAdmxPSAppDeployToolkit {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter '*.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -2997,7 +3240,7 @@ function Invoke-EvergreenAdmxDevolutionsRDM {
             # copy
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Directory -Filter 'Policies' | Select-Object -First 1).FullName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -3062,7 +3305,7 @@ function Invoke-EvergreenAdmxPowerToy {
 
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'PowerToys.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force
             return $Evergreen
@@ -3124,7 +3367,7 @@ function Invoke-EvergreenAdmxWindowsTerminal {
 
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'WindowsTerminal.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force
             return $Evergreen
@@ -3185,7 +3428,7 @@ function Invoke-EvergreenAdmxThunderbird {
 
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'thunderbird.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force
             return $Evergreen
@@ -3255,7 +3498,7 @@ function Invoke-EvergreenAdmxDropbox {
             }
 
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force
             return $Evergreen
@@ -3352,7 +3595,7 @@ function Invoke-EvergreenAdmxFoxit {
             }
 
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $StagingFolder -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $StagingFolder -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force
             return $Evergreen
@@ -3413,7 +3656,7 @@ function Invoke-EvergreenAdmxLibreOffice {
 
             $SourceAdmx = (Get-ChildItem -Path $TempFolder -Recurse -Filter 'Collabora-Office.admx' | Select-Object -First 1).DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force
             return $Evergreen
@@ -3509,7 +3752,7 @@ function Invoke-EvergreenAdmxHPAnyware {
             }
 
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             Remove-Item -Path $TempFolder -Recurse -Force -ErrorAction SilentlyContinue
             return $Evergreen
@@ -3585,7 +3828,7 @@ function Invoke-EvergreenAdmxWindows {
             # copy
             $SourceAdmx = "$($TempFolder)\Microsoft Group Policy\$($InstallFolder.Name)\PolicyDefinitions"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $TempFolder -Recurse -Force
@@ -3644,7 +3887,7 @@ function Invoke-EvergreenAdmxEdge {
             # Copy
             $SourceAdmx = "$($env:TEMP)\$($ProductName)\windows\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # Cleanup
             Remove-Item -Path $OutFile -Force
@@ -3780,6 +4023,18 @@ function Invoke-EvergreenAdmxOneDrive {
                 Write-Warning "No ADMX files found for '$($ProductName)'"
             }
 
+            if ($StampAdmxRevision) {
+                $normalizedRevision = ConvertTo-AdmxRevisionString -Version $Evergreen.Version
+                if ($normalizedRevision) {
+                    if (Test-Path -LiteralPath $TargetAdmx) {
+                        Set-AdmxRevision -Path $TargetAdmx -Revision $normalizedRevision
+                    }
+                    if ($PolicyStore) {
+                        Set-AdmxRevision -Path $PolicyStore -Revision $normalizedRevision
+                    }
+                }
+            }
+
             if (-not $PreferLocalOneDrive) {
                 # Uninstall
                 Write-Verbose 'Uninstalling Microsoft OneDrive installer'
@@ -3840,7 +4095,7 @@ function Invoke-EvergreenAdmx365App {
             # Copy
             $SourceAdmx = "$($env:TEMP)\office\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # Cleanup
             Remove-Item -Path "$($env:TEMP)\office" -Recurse -Force
@@ -3906,6 +4161,16 @@ function Invoke-EvergreenAdmxFSLogix {
                 Copy-Item -Path "$($SourceAdmx)\*.adml" -Destination "$($PolicyStore)en-US" -Force
             }
 
+            if ($StampAdmxRevision) {
+                $normalizedRevision = ConvertTo-AdmxRevisionString -Version $Evergreen.Version
+                if ($normalizedRevision) {
+                    Set-AdmxRevision -Path $TargetAdmx -Revision $normalizedRevision
+                    if ($PolicyStore) {
+                        Set-AdmxRevision -Path $PolicyStore -Revision $normalizedRevision
+                    }
+                }
+            }
+
             # cleanup
             Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
 
@@ -3958,7 +4223,7 @@ Function Invoke-EvergreenAdmxChrome {
             # Copy
             $SourceAdmx = "$($env:TEMP)\chromeadmx\windows\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # Cleanup
             Remove-Item -Path "$($env:TEMP)\chromeadmx" -Recurse -Force
@@ -3978,7 +4243,7 @@ Function Invoke-EvergreenAdmxChrome {
             # Copy
             $SourceAdmx = "$($env:TEMP)\chromeupdateadmx\GoogleUpdateAdmx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Quiet -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Quiet -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # Cleanup
             Remove-Item -Path "$($env:TEMP)\chromeupdateadmx" -Recurse -Force
@@ -4032,7 +4297,7 @@ function Invoke-EvergreenAdmxAdobeAcrobat {
             # copy
             $SourceAdmx = "$($env:TEMP)\$($ProductName)"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
@@ -4086,7 +4351,7 @@ function Invoke-EvergreenAdmxAdobeReader {
             # copy
             $SourceAdmx = "$($env:TEMP)\AdobeReader"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\AdobeReader" -Recurse -Force
@@ -4142,7 +4407,7 @@ function Invoke-EvergreenAdmxWorkspaceApp {
             # $SourceAdmx = "$($env:TEMP)\citrixworkspaceapp\$($Evergreen.URI.Split("/")[-2].Split("?")[0].SubString(0,$Evergreen.URI.Split("/")[-2].Split("?")[0].IndexOf(".")))"
             $SourceAdmx = (Get-ChildItem -Path "$($env:TEMP)\citrixworkspaceapp\$($Evergreen.URI.Split('/')[-2].Split('?')[0].SubString(0,$Evergreen.URI.Split('/')[-2].Split('?')[0].IndexOf('.')))" -Include '*.admx' -Recurse)[0].DirectoryName
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\citrixworkspaceapp" -Recurse -Force
@@ -4197,7 +4462,7 @@ function Invoke-EvergreenAdmxFirefox {
             # copy
             $SourceAdmx = "$($env:TEMP)\firefoxadmx\windows"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\firefoxadmx" -Recurse -Force
@@ -4260,7 +4525,7 @@ function Invoke-EvergreenAdmxZoom {
             # copy
             $SourceAdmx = "$($env:TEMP)\$($ProductName)"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
@@ -4323,7 +4588,7 @@ function Invoke-EvergreenAdmxZoomVDI {
             # copy
             $SourceAdmx = "$($env:TEMP)\$($ProductName)"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\$($ProductName)" -Recurse -Force
@@ -4381,7 +4646,7 @@ function Invoke-EvergreenAdmxBISF {
             # copy
             $SourceAdmx = "$($env:TEMP)\bisfadmx\$($folder)\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\bisfadmx" -Recurse -Force
@@ -4428,7 +4693,7 @@ function Invoke-EvergreenAdmxCustomPolicy {
             # copy
             $SourceAdmx = "$($Evergreen.URI)"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName "$($ProductName)" -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName "$($ProductName)" -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             return $Evergreen
         } catch {
@@ -4484,7 +4749,7 @@ function Invoke-EvergreenAdmxAvd {
             # copy
             $SourceAdmx = "$($env:TEMP)\$($ProductName)"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path $OutFile -Force
@@ -4540,7 +4805,7 @@ function Invoke-EvergreenAdmxWinget {
             # copy
             $SourceAdmx = "$($env:TEMP)\wingetadmx\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\wingetadmx" -Recurse -Force
@@ -4604,7 +4869,7 @@ function Invoke-EvergreenAdmxBrave {
             # copy
             $SourceAdmx = "$($env:TEMP)\braveadmx\windows\admx"
             $TargetAdmx = "$($WorkingDirectory)\admx$($ProductFolder)"
-            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages
+            Copy-Admx -SourceFolder $SourceAdmx -TargetFolder $TargetAdmx -PolicyStore $PolicyStore -ProductName $ProductName -Languages $Languages -Revision $(if ($StampAdmxRevision) { $Evergreen.Version })
 
             # cleanup
             Remove-Item -Path "$($env:TEMP)\braveadmx" -Recurse -Force

--- a/README.md
+++ b/README.md
@@ -160,41 +160,30 @@ Thin orchestrator sample: [`samples/Update-PolicyDefinitions.ps1`](samples/Updat
 
 Pass parameters with a leading `-` (PowerShell syntax), for example `-WorkingDirectory` or `-Include`.
 
-### -WindowsVersion
+### -CleanPolicyStore
 
-Specifies Windows major version. Supports `10`, `11`, `2022`, or `2025`. Default is `11`.
+After processing, removes known obsolete or conflicting files from `-PolicyStore` and repairs missing ADMLs:
 
-### -WindowsFeatureVersion
+- `WinStoreUI.admx` / `.adml` (replaced by `WindowsStore.admx`; namespace conflict if both present)
+- `Microsoft-Windows-Geolocation-WLPAdm.admx` / `.adml` (replaced by `LocationProviderAdm.admx`)
+- Legacy Office templates matching `*12*`–`*15*`
+- Adobe Acrobat/Reader Classic 2017 and 2020 templates
+- Citrix Profile Management `ctxprofile*` templates
+- `CitrixBase.admx` / `.adml` (no longer required; see [CTX696338](https://support.citrix.com/external/article/CTX696338/citrix-workspace-app-admx-download-does.html))
+- Non-`.admx`/`.adml` files at the store root and non-language extract folders
+- Missing language `.adml` files: copies from `en-US` into requested `-Languages` folders when available; warns if an `.admx` has no ADML at all
 
-Specifies the Windows 10 or Windows 11 feature version to get the Admx files for.
+Requires `-PolicyStore`. Supports `-WhatIf`.
 
-- Windows 10: `21H2`, `22H2` (default `22H2`)
-- Windows 11: `23H2`, `24H2`, `25H2` (default `25H2`)
+### -CleanPolicyStoreOnly
 
-Ignored when `-WindowsVersion` is `2022` or `2025`.
+Skips Admx downloads and only runs the Policy Store cleanup described above. Requires `-PolicyStore`. Supports `-WhatIf`.
 
-Current Windows 11 ADMX templates (`23H2` / `24H2` / `25H2`) can also manage Windows 10 clients; some settings apply only to newer OS versions. Windows 10 `21H2` / `22H2` remain available for LTSC and ESU — see [Notes](#notes).
+### -CreateScheduledTask
 
-### -WorkingDirectory
+Creates or updates a Windows Scheduled Task named `EvergreenAdmx` that runs this script weekly (Sunday at 01:00) as `SYSTEM` with highest privileges. Compatible with Windows Server 2022 and 2025 via `Register-ScheduledTask`.
 
-Specifies a working directory for the script.
-
-- Admx files are stored in a subdirectory called `admx`
-- Downloaded files are stored in a subdirectory called `downloads`
-
-Defaults to the current script location.
-
-### -PolicyStore
-
-Specifies a Policy Store location to copy the Admx files to after processing. When this path does not exist, the script creates the Policy Store directory and language subfolders from `-Languages`.
-
-### -Languages
-
-Specifies an array of languages to process. Entries must be in `xy-XY` format (also accepts short forms such as `es` and region tags such as `es-419`). Defaults to `en-US`.
-
-### -UseProductFolders
-
-When set, Admx files are copied to their respective product folders under `admx` in the WorkingDirectory.
+Other parameters bound on the same command line are forwarded to the task action. The script exits after registering the task and does not download Admx files in that run. Change day/time later in Task Scheduler.
 
 ### -CustomPolicyStore
 
@@ -229,8 +218,8 @@ Shared defaults: `Microsoft Edge`, `Microsoft OneDrive`, `Microsoft 365 Apps`, `
 - [`1Password`][ref-1password]
 - [`ABBYY FineReader PDF`][ref-abbyy] (FineReader 16)
 - [`Admin By Request`][ref-admin-by-request]
-- [`Adobe DC`][ref-adobe-dc] (community combined template)
 - [`Adobe Acrobat`][ref-adobe-acrobat] (Continuous track)
+- [`Adobe DC`][ref-adobe-dc] (community combined template)
 - [`Adobe Reader`][ref-adobe-reader] (Continuous track)
 - [`BIS-F`][ref-bisf] (Base Image Script Framework)
 - [`Brave Browser`][ref-brave]
@@ -279,34 +268,17 @@ Shared defaults: `Microsoft Edge`, `Microsoft OneDrive`, `Microsoft 365 Apps`, `
 
 </details>
 
+### -Languages
+
+Specifies an array of languages to process. Entries must be in `xy-XY` format (also accepts short forms such as `es` and region tags such as `es-419`). Defaults to `en-US`.
+
+### -PolicyStore
+
+Specifies a Policy Store location to copy the Admx files to after processing. When this path does not exist, the script creates the Policy Store directory and language subfolders from `-Languages`.
+
 ### -PreferLocalOneDrive
 
 Microsoft OneDrive Admx files are only available after installing OneDrive. If this script is running on a machine that has OneDrive installed locally, use this switch to prevent automatically uninstalling OneDrive.
-
-### -CleanPolicyStore
-
-After processing, removes known obsolete or conflicting files from `-PolicyStore` and repairs missing ADMLs:
-
-- `WinStoreUI.admx` / `.adml` (replaced by `WindowsStore.admx`; namespace conflict if both present)
-- `Microsoft-Windows-Geolocation-WLPAdm.admx` / `.adml` (replaced by `LocationProviderAdm.admx`)
-- Legacy Office templates matching `*12*`–`*15*`
-- Adobe Acrobat/Reader Classic 2017 and 2020 templates
-- Citrix Profile Management `ctxprofile*` templates
-- `CitrixBase.admx` / `.adml` (no longer required; see [CTX696338](https://support.citrix.com/external/article/CTX696338/citrix-workspace-app-admx-download-does.html))
-- Non-`.admx`/`.adml` files at the store root and non-language extract folders
-- Missing language `.adml` files: copies from `en-US` into requested `-Languages` folders when available; warns if an `.admx` has no ADML at all
-
-Requires `-PolicyStore`. Supports `-WhatIf`.
-
-### -CleanPolicyStoreOnly
-
-Skips Admx downloads and only runs the Policy Store cleanup described above. Requires `-PolicyStore`. Supports `-WhatIf`.
-
-### -CreateScheduledTask
-
-Creates or updates a Windows Scheduled Task named `EvergreenAdmx` that runs this script weekly (Sunday at 01:00) as `SYSTEM` with highest privileges. Compatible with Windows Server 2022 and 2025 via `Register-ScheduledTask`.
-
-Other parameters bound on the same command line are forwarded to the task action. The script exits after registering the task and does not download Admx files in that run. Change day/time later in Task Scheduler.
 
 ### -StampAdmxRevision
 
@@ -319,6 +291,34 @@ Only attributes currently set to `1.0` are updated:
 - ADML `policyDefinitionResources/@revision`
 
 Higher vendor revisions are left unchanged. Default is off so Central Policy Store copies keep vendor XML unless you opt in.
+
+### -UseProductFolders
+
+When set, Admx files are copied to their respective product folders under `admx` in the WorkingDirectory.
+
+### -WindowsFeatureVersion
+
+Specifies the Windows 10 or Windows 11 feature version to get the Admx files for.
+
+- Windows 10: `21H2`, `22H2` (default `22H2`)
+- Windows 11: `23H2`, `24H2`, `25H2` (default `25H2`)
+
+Ignored when `-WindowsVersion` is `2022` or `2025`.
+
+Current Windows 11 ADMX templates (`23H2` / `24H2` / `25H2`) can also manage Windows 10 clients; some settings apply only to newer OS versions. Windows 10 `21H2` / `22H2` remain available for LTSC and ESU — see [Notes](#notes).
+
+### -WindowsVersion
+
+Specifies Windows major version. Supports `10`, `11`, `2022`, or `2025`. Default is `11`.
+
+### -WorkingDirectory
+
+Specifies a working directory for the script.
+
+- Admx files are stored in a subdirectory called `admx`
+- Downloaded files are stored in a subdirectory called `downloads`
+
+Defaults to the current script location.
 
 <a id="breaking-changes"></a>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This script solves both problems:
 
 Named as an homage to the [Evergreen module](https://github.com/EUCPilots/evergreen-module) by Aaron Parker ([@stealthpuppy](https://x.com/stealthpuppy)).
 
-## Contents
+## 📚 Contents
 
 - [Requirements](#requirements)
 - [Install](#install)
@@ -156,7 +156,7 @@ Thin orchestrator sample: [`samples/Update-PolicyDefinitions.ps1`](samples/Updat
 
 <a id="parameters"></a>
 
-## ⚙ Parameters
+## ⚙️ Parameters
 
 Pass parameters with a leading `-` (PowerShell syntax), for example `-WorkingDirectory` or `-Include`.
 
@@ -226,56 +226,56 @@ Shared defaults: `Microsoft Edge`, `Microsoft OneDrive`, `Microsoft 365 Apps`, `
 <details>
 <summary>Supported <code>-Include</code> products</summary>
 
-- `1Password`
-- `ABBYY FineReader PDF` (FineReader 16)
-- `Admin By Request`
-- `Adobe DC` (community combined template)
-- `Adobe Acrobat` (Continuous track)
-- `Adobe Reader` (Continuous track)
-- `BIS-F` (Base Image Script Framework)
-- `Brave Browser`
-- `Citrix Workspace app`
-- `Custom Policy Store` (local / UNC path you provide)
-- `Dell Command Update` (latest Universal installer via winget)
-- `Devolutions Remote Desktop Manager`
-- `Dropbox`
-- `Foxit PDF` (Reader + Editor)
-- `Google Chrome`
-- `GoTo` (GoTo app / GoTo Connect)
-- `HP Anyware` (PCoIP ADMX from Standard Agent; requires 7-Zip)
-- `Lenovo Dock Manager` (policy_setup.exe Group Policy templates)
-- `LibreOffice` (Collabora Office / LibreOffice GPO templates)
-- `Microsoft 365 Apps`
-- `Microsoft AVD`
-- `Microsoft Clipchamp`
-- `Microsoft Edge`
-- `Microsoft FSLogix`
-- `Microsoft Notepad`
-- `Microsoft OneDrive` (local installation or download from Evergreen)
-- `Microsoft PowerToys`
-- `Microsoft Visual Studio`
-- `Microsoft VS Code`
-- `Microsoft Winget`
-- `Mozilla Firefox`
-- `Mozilla Thunderbird`
-- `PDF-XChange` (Editor, Tools, Driver, Updater, Vault)
-- `PSAppDeployToolkit`
-- `RealVNC Connect` (Server + Viewer)
-- `Schannel` (Crosse Schannel GPO templates)
-- `Security ADMX` (Custom template for Windows hardening)
-- `Slack`
-- `Specops Authentication Client` (on-prem + Entra ID)
-- `TeamViewer`
-- `Windows 10` (`21H2` / `22H2`)
-- `Windows 11` (`23H2` / `24H2` / `25H2`)
-- `Windows 2022` (Windows Server 2022)
-- `Windows 2025` (Windows Server 2025)
-- `Windows Terminal`
-- `Winget-AutoUpdate`
-- `Winget-AutoUpdate-Intune`
-- `WSL` (Windows Subsystem for Linux Intune ADMX)
-- `Zoom`
-- `Zoom VDI`
+- [`1Password`][ref-1password]
+- [`ABBYY FineReader PDF`][ref-abbyy] (FineReader 16)
+- [`Admin By Request`][ref-admin-by-request]
+- [`Adobe DC`][ref-adobe-dc] (community combined template)
+- [`Adobe Acrobat`][ref-adobe-acrobat] (Continuous track)
+- [`Adobe Reader`][ref-adobe-reader] (Continuous track)
+- [`BIS-F`][ref-bisf] (Base Image Script Framework)
+- [`Brave Browser`][ref-brave]
+- [`Citrix Workspace app`][ref-citrix]
+- [`Custom Policy Store`][ref-custom-policy-store] (local / UNC path you provide)
+- [`Dell Command Update`][ref-dell-command-update] (latest Universal installer via winget)
+- [`Devolutions Remote Desktop Manager`][ref-devolutions]
+- [`Dropbox`][ref-dropbox]
+- [`Foxit PDF`][ref-foxit] (Reader + Editor)
+- [`Google Chrome`][ref-chrome]
+- [`GoTo`][ref-goto] (GoTo app / GoTo Connect)
+- [`HP Anyware`][ref-hp-anyware] (PCoIP ADMX from Standard Agent; requires 7-Zip)
+- [`Lenovo Dock Manager`][ref-lenovo-dock] (policy_setup.exe Group Policy templates)
+- [`LibreOffice`][ref-libreoffice] (Collabora Office / LibreOffice GPO templates)
+- [`Microsoft 365 Apps`][ref-365-apps]
+- [`Microsoft AVD`][ref-avd]
+- [`Microsoft Clipchamp`][ref-clipchamp]
+- [`Microsoft Edge`][ref-edge]
+- [`Microsoft FSLogix`][ref-fslogix]
+- [`Microsoft Notepad`][ref-notepad]
+- [`Microsoft OneDrive`][ref-onedrive] (local installation or download from Evergreen)
+- [`Microsoft PowerToys`][ref-powertoys]
+- [`Microsoft Visual Studio`][ref-visual-studio]
+- [`Microsoft VS Code`][ref-vscode]
+- [`Microsoft Winget`][ref-winget]
+- [`Mozilla Firefox`][ref-firefox]
+- [`Mozilla Thunderbird`][ref-thunderbird]
+- [`PDF-XChange`][ref-pdf-xchange] (Editor, Tools, Driver, Updater, Vault)
+- [`PSAppDeployToolkit`][ref-psadt]
+- [`RealVNC Connect`][ref-realvnc] (Server + Viewer)
+- [`Schannel`][ref-schannel] (Crosse Schannel GPO templates)
+- [`Security ADMX`][ref-security-admx] (Custom template for Windows hardening)
+- [`Slack`][ref-slack]
+- [`Specops Authentication Client`][ref-specops] (on-prem + Entra ID)
+- [`TeamViewer`][ref-teamviewer]
+- [`Windows 10`][ref-win10-22h2] ([`21H2`][ref-win10-21h2] / [`22H2`][ref-win10-22h2])
+- [`Windows 11`][ref-win11-25h2] ([`23H2`][ref-win11-23h2] / [`24H2`][ref-win11-24h2] / [`25H2`][ref-win11-25h2])
+- [`Windows 2022`][ref-winserver-2022] (Windows Server 2022)
+- [`Windows 2025`][ref-winserver-2025] (Windows Server 2025)
+- [`Windows Terminal`][ref-windows-terminal]
+- [`Winget-AutoUpdate`][ref-wau]
+- [`Winget-AutoUpdate-Intune`][ref-wau-intune]
+- [`WSL`][ref-wsl] (Windows Subsystem for Linux Intune ADMX)
+- [`Zoom`][ref-zoom]
+- [`Zoom VDI`][ref-zoom-vdi]
 
 </details>
 
@@ -322,7 +322,7 @@ Higher vendor revisions are left unchanged. Default is off so Central Policy Sto
 
 <a id="breaking-changes"></a>
 
-## ⚠ Breaking changes
+## ⚠️ Breaking changes
 
 Highlights in **2607.0** (full history and earlier breaking changes in the [Changelog](CHANGELOG.md)):
 
@@ -377,3 +377,56 @@ This project is licensed under the [MIT License](LICENSE).
 [x-follow-badge]: https://img.shields.io/twitter/follow/menschab?style=flat-square&logo=x
 [x-follow]: https://x.com/menschab
 [poshgallery-evergreenadmx]: https://www.powershellgallery.com/packages/EvergreenAdmx/
+[ref-1password]: https://support.1password.com/mobile-device-management/?windows=
+[ref-abbyy]: https://help.abbyy.com/en-us/finereader/16/admin_guide/gpo_domain/
+[ref-admin-by-request]: https://www.adminbyrequest.com/ADMX
+[ref-adobe-acrobat]: https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/misc/AcrobatADMTemplate.zip
+[ref-adobe-dc]: https://github.com/systmworks/Adobe-DC-ADMX
+[ref-adobe-reader]: https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/misc/ReaderADMTemplate.zip
+[ref-bisf]: https://github.com/EUCweb/BIS-F
+[ref-brave]: https://github.com/brave/brave-browser/wiki/Deploying-Brave-with-Group-Policy
+[ref-citrix]: https://docs.citrix.com/en-us/citrix-workspace-app-for-windows/group-policy
+[ref-custom-policy-store]: https://learn.microsoft.com/en-us/troubleshoot/windows-client/group-policy/create-and-manage-central-store
+[ref-dell-command-update]: https://www.dell.com/support/kbdoc/en-us/000293701/how-do-i-access-amdx-and-adml-files-for-use-with-dell-command-update
+[ref-devolutions]: https://docs.devolutions.net/rdm/knowledge-base/how-to-articles/apply-policies-gpos
+[ref-dropbox]: https://github.com/dropbox/GPO-Templates
+[ref-foxit]: https://kb.foxit.com/s/articles/360040241112-Available-GPO-templates
+[ref-goto]: https://goto-desktop.goto.com/GoToAppAdministrativeTemplates.zip
+[ref-hp-anyware]: https://anyware.hp.com/components/standard-agent-for-windows/26.05/documentation/administrators-guide/reference/install-gpo-template-files
+[ref-lenovo-dock]: https://download.lenovo.com/consumer/options/policy_setup.exe
+[ref-libreoffice]: https://github.com/CollaboraOnline/ADMX
+[ref-chrome]: https://chromeenterprise.google/policies/
+[ref-pdf-xchange]: https://www.pdf-xchange.com/Tracker%5FAD%5FAdministrativeTemplates.zip
+[ref-powertoys]: https://github.com/microsoft/PowerToys/releases
+[ref-realvnc]: https://downloads.realvnc.com/download/file/policy.files/RealVNC-server-admx-templates-Latest.zip
+[ref-specops]: https://download.specopssoft.com/Release/Client/Specops.Client.AdmxTemplates.zip
+[ref-thunderbird]: https://github.com/thunderbird/policy-templates
+[ref-windows-terminal]: https://github.com/microsoft/terminal/releases
+[ref-wsl]: https://github.com/microsoft/WSL/tree/master/intune
+[ref-365-apps]: https://www.microsoft.com/en-us/download/details.aspx?id=49030
+[ref-avd]: https://aka.ms/avdgpo
+[ref-clipchamp]: https://www.microsoft.com/en-us/download/details.aspx?id=105674
+[ref-edge]: https://learn.microsoft.com/en-us/deployedge/configure-microsoft-edge
+[ref-fslogix]: https://learn.microsoft.com/en-us/fslogix/how-to-use-group-policy-templates
+[ref-notepad]: https://download.microsoft.com/download/72ea16a9-4cc9-4032-945d-3a56a483d034/WindowsNotepadAdminTemplates.cab
+[ref-onedrive]: https://learn.microsoft.com/en-us/sharepoint/use-group-policy
+[ref-visual-studio]: https://www.microsoft.com/en-us/download/details.aspx?id=104405
+[ref-vscode]: https://code.visualstudio.com/docs/setup/enterprise
+[ref-win10-21h2]: https://www.microsoft.com/en-us/download/details.aspx?id=104042
+[ref-win10-22h2]: https://www.microsoft.com/en-us/download/details.aspx?id=104677
+[ref-win11-23h2]: https://www.microsoft.com/en-us/download/details.aspx?id=105667
+[ref-win11-24h2]: https://www.microsoft.com/en-us/download/details.aspx?id=106254
+[ref-win11-25h2]: https://www.microsoft.com/en-us/download/details.aspx?id=108542
+[ref-winserver-2022]: https://www.microsoft.com/en-us/download/details.aspx?id=104003
+[ref-winserver-2025]: https://www.microsoft.com/en-us/download/details.aspx?id=106295
+[ref-winget]: https://github.com/microsoft/winget-cli/releases
+[ref-firefox]: https://github.com/mozilla/policy-templates
+[ref-psadt]: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit
+[ref-schannel]: https://github.com/Crosse/SchannelGroupPolicy
+[ref-security-admx]: https://github.com/Harvester57/Security-ADMX
+[ref-slack]: https://slack.com/help/articles/11906214948755-Manage-desktop-app-configurations
+[ref-teamviewer]: https://github.com/systmworks/TeamViewer-ADMX
+[ref-wau]: https://github.com/Romanitho/Winget-AutoUpdate
+[ref-wau-intune]: https://github.com/Weatherlights/Winget-AutoUpdate-Intune
+[ref-zoom]: https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0065466
+[ref-zoom-vdi]: https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064784

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Shared defaults: `Microsoft Edge`, `Microsoft OneDrive`, `Microsoft 365 Apps`, `
 <summary>Supported <code>-Include</code> products</summary>
 
 - `1Password`
+- `ABBYY FineReader PDF` (FineReader 16)
+- `Admin By Request`
 - `Adobe DC` (community combined template)
 - `Adobe Acrobat` (Continuous track)
 - `Adobe Reader` (Continuous track)
@@ -239,7 +241,9 @@ Shared defaults: `Microsoft Edge`, `Microsoft OneDrive`, `Microsoft 365 Apps`, `
 - `Dropbox`
 - `Foxit PDF` (Reader + Editor)
 - `Google Chrome`
+- `GoTo` (GoTo app / GoTo Connect)
 - `HP Anyware` (PCoIP ADMX from Standard Agent; requires 7-Zip)
+- `Lenovo Dock Manager` (policy_setup.exe Group Policy templates)
 - `LibreOffice` (Collabora Office / LibreOffice GPO templates)
 - `Microsoft 365 Apps`
 - `Microsoft AVD`
@@ -254,10 +258,13 @@ Shared defaults: `Microsoft Edge`, `Microsoft OneDrive`, `Microsoft 365 Apps`, `
 - `Microsoft Winget`
 - `Mozilla Firefox`
 - `Mozilla Thunderbird`
+- `PDF-XChange` (Editor, Tools, Driver, Updater, Vault)
 - `PSAppDeployToolkit`
+- `RealVNC Connect` (Server + Viewer)
 - `Schannel` (Crosse Schannel GPO templates)
 - `Security ADMX` (Custom template for Windows hardening)
 - `Slack`
+- `Specops Authentication Client` (on-prem + Entra ID)
 - `TeamViewer`
 - `Windows 10` (`21H2` / `22H2`)
 - `Windows 11` (`23H2` / `24H2` / `25H2`)
@@ -266,6 +273,7 @@ Shared defaults: `Microsoft Edge`, `Microsoft OneDrive`, `Microsoft 365 Apps`, `
 - `Windows Terminal`
 - `Winget-AutoUpdate`
 - `Winget-AutoUpdate-Intune`
+- `WSL` (Windows Subsystem for Linux Intune ADMX)
 - `Zoom`
 - `Zoom VDI`
 

--- a/README.md
+++ b/README.md
@@ -277,14 +277,16 @@ Microsoft OneDrive Admx files are only available after installing OneDrive. If t
 
 ### -CleanPolicyStore
 
-After processing, removes known obsolete or conflicting files from `-PolicyStore`:
+After processing, removes known obsolete or conflicting files from `-PolicyStore` and repairs missing ADMLs:
 
-- `WinStoreUI.admx` / `.adml` (known Group Policy conflict)
+- `WinStoreUI.admx` / `.adml` (replaced by `WindowsStore.admx`; namespace conflict if both present)
+- `Microsoft-Windows-Geolocation-WLPAdm.admx` / `.adml` (replaced by `LocationProviderAdm.admx`)
 - Legacy Office templates matching `*12*`–`*15*`
 - Adobe Acrobat/Reader Classic 2017 and 2020 templates
 - Citrix Profile Management `ctxprofile*` templates
 - `CitrixBase.admx` / `.adml` (no longer required; see [CTX696338](https://support.citrix.com/external/article/CTX696338/citrix-workspace-app-admx-download-does.html))
 - Non-`.admx`/`.adml` files at the store root and non-language extract folders
+- Missing language `.adml` files: copies from `en-US` into requested `-Languages` folders when available; warns if an `.admx` has no ADML at all
 
 Requires `-PolicyStore`. Supports `-WhatIf`.
 
@@ -297,6 +299,18 @@ Skips Admx downloads and only runs the Policy Store cleanup described above. Req
 Creates or updates a Windows Scheduled Task named `EvergreenAdmx` that runs this script weekly (Sunday at 01:00) as `SYSTEM` with highest privileges. Compatible with Windows Server 2022 and 2025 via `Register-ScheduledTask`.
 
 Other parameters bound on the same command line are forwarded to the task action. The script exits after registering the task and does not download Admx files in that run. Change day/time later in Task Scheduler.
+
+### -StampAdmxRevision
+
+When set, stamps ADMX/ADML `revision` attributes from the product release Version (GitHub release, download page, etc.) normalized to the ADMX `versionString` **Major.Minor** form (for example `143.0.3624.0` becomes `143.0`). This helps Intune Imported Administrative Templates show a meaningful Version column.
+
+Only attributes currently set to `1.0` are updated:
+
+- ADMX `policyDefinitions/@revision`
+- ADMX `resources/@minRequiredRevision` (when also `1.0`)
+- ADML `policyDefinitionResources/@revision`
+
+Higher vendor revisions are left unchanged. Default is off so Central Policy Store copies keep vendor XML unless you opt in.
 
 <a id="breaking-changes"></a>
 
@@ -314,6 +328,7 @@ Highlights in **2607.0** (full history and earlier breaking changes in the [Chan
 ## 📝 Notes
 
 - This script has not been tested on Windows Core
+- Use `-StampAdmxRevision` when preparing templates for Intune so the Version column reflects the product release (Major.Minor); this does not bypass Intune namespace conflicts on re-upload
 - Some Admx files can only be obtained by installing the downloaded package (for example Windows 10/11 Admx MSI packages, and OneDrive after install)
 - If you use the script to download Windows 10 or Windows 11 Admx files, remove any existing installs of those Admx MSI packages first, or the script will fail
 - For those packages the script installs the package, copies the Admx files, then uninstalls the package
@@ -321,6 +336,8 @@ Highlights in **2607.0** (full history and earlier breaking changes in the [Chan
 - HP Anyware ADMX requires `winget` (to resolve the current version) and 7-Zip to extract `PCoIP.admx` from the Standard Agent installer
 - Windows 10 `22H2` is the last GA release (mainstream support ended October 14, 2025); organizations on [Extended Security Updates (ESU)](https://learn.microsoft.com/en-us/windows/whats-new/extended-security-updates) still need matching ADMX templates
 - Windows 10 `21H2` is the base for **Windows 10 Enterprise LTSC 2021** (supported until January 2027, longer for IoT Enterprise LTSC)
+- Use `-CleanPolicyStore` (or `-CleanPolicyStoreOnly`) to remove known conflicting ADMX files (for example `WinStoreUI` / `Microsoft-Windows-Geolocation-WLPAdm`) and copy missing language ADMLs from `en-US` when available
+- Some Microsoft ADMX upgrades change GPO registry value types or paths (for example ErrorReporting `DefaultConsent` “unexpected type”, or SkyDrive → OneDrive registry keys). Those require rebuilding the affected GPO settings; the script does not rewrite `registry.pol`. See [Known issues for managing Group Policy clients](https://learn.microsoft.com/en-us/troubleshoot/windows-client/active-directory/known-issues-for-group-policy-clients)
 
 <a id="roadmap"></a>
 
@@ -329,7 +346,6 @@ Highlights in **2607.0** (full history and earlier breaking changes in the [Chan
 - Add logging options
 - Add notification options
 - Detect user domain automatically
-- Add ADMX versioning automatically (useful for Intune)
 
 <a id="credits"></a>
 

--- a/tests/EvergreenAdmx.Tests.ps1
+++ b/tests/EvergreenAdmx.Tests.ps1
@@ -42,6 +42,8 @@ Describe 'EvergreenAdmx script surface' {
         Get-Command -Name Initialize-PolicyStore -CommandType Function | Should -Not -BeNullOrEmpty
         Get-Command -Name Get-EvergreenAdmxProductCatalog -CommandType Function | Should -Not -BeNullOrEmpty
         Get-Command -Name Resolve-EvergreenAdmxInclude -CommandType Function | Should -Not -BeNullOrEmpty
+        Get-Command -Name ConvertTo-AdmxRevisionString -CommandType Function | Should -Not -BeNullOrEmpty
+        Get-Command -Name Set-AdmxRevision -CommandType Function | Should -Not -BeNullOrEmpty
     }
 }
 
@@ -228,10 +230,12 @@ Describe 'Resolve-EvergreenAdmxInclude' {
 }
 
 Describe 'Get-EvergreenAdmxObsoleteFilePattern' {
-    It 'includes WinStoreUI, legacy Office, Adobe Classic, ctxprofile, and CitrixBase patterns' {
+    It 'includes WinStoreUI, Geolocation WLPAdm, legacy Office, Adobe Classic, ctxprofile, and CitrixBase patterns' {
         $patterns = Get-EvergreenAdmxObsoleteFilePattern
         $patterns | Should -Contain 'WinStoreUI.admx'
         $patterns | Should -Contain 'WinStoreUI.adml'
+        $patterns | Should -Contain 'Microsoft-Windows-Geolocation-WLPAdm.admx'
+        $patterns | Should -Contain 'Microsoft-Windows-Geolocation-WLPAdm.adml'
         $patterns | Should -Contain '*12*.admx'
         $patterns | Should -Contain '*15*.adml'
         $patterns | Should -Contain 'Acrobat2017.admx'
@@ -277,10 +281,15 @@ Describe 'Clear-ObsoleteAdmx' {
         Set-Content -Path (Join-Path $script:StoreRoot 'windows.admx') -Value 'keep'
         Set-Content -Path (Join-Path $script:StoreRoot 'en-US\windows.adml') -Value 'keep'
         Set-Content -Path (Join-Path $script:StoreRoot 'office16.admx') -Value 'keep'
+        Set-Content -Path (Join-Path $script:StoreRoot 'en-US\office16.adml') -Value 'keep'
+        Set-Content -Path (Join-Path $script:StoreRoot 'LocationProviderAdm.admx') -Value 'keep'
+        Set-Content -Path (Join-Path $script:StoreRoot 'en-US\LocationProviderAdm.adml') -Value 'keep'
 
         # Obsolete
         Set-Content -Path (Join-Path $script:StoreRoot 'WinStoreUI.admx') -Value 'remove'
         Set-Content -Path (Join-Path $script:StoreRoot 'en-US\WinStoreUI.adml') -Value 'remove'
+        Set-Content -Path (Join-Path $script:StoreRoot 'Microsoft-Windows-Geolocation-WLPAdm.admx') -Value 'remove'
+        Set-Content -Path (Join-Path $script:StoreRoot 'en-US\Microsoft-Windows-Geolocation-WLPAdm.adml') -Value 'remove'
         Set-Content -Path (Join-Path $script:StoreRoot 'excel15.admx') -Value 'remove'
         Set-Content -Path (Join-Path $script:StoreRoot 'en-US\excel15.adml') -Value 'remove'
         Set-Content -Path (Join-Path $script:StoreRoot 'Acrobat2017.admx') -Value 'remove'
@@ -305,6 +314,8 @@ Describe 'Clear-ObsoleteAdmx' {
         $removed.Count | Should -BeGreaterThan 0
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'WinStoreUI.admx') | Should -BeFalse
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'en-US\WinStoreUI.adml') | Should -BeFalse
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'Microsoft-Windows-Geolocation-WLPAdm.admx') | Should -BeFalse
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'en-US\Microsoft-Windows-Geolocation-WLPAdm.adml') | Should -BeFalse
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'excel15.admx') | Should -BeFalse
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'Acrobat2017.admx') | Should -BeFalse
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'AcrobatReader2020.admx') | Should -BeFalse
@@ -316,17 +327,71 @@ Describe 'Clear-ObsoleteAdmx' {
 
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'windows.admx') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'office16.admx') | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'LocationProviderAdm.admx') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'en-US') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'fr-FR') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'en-US\windows.adml') | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'fr-FR\windows.adml') | Should -BeTrue
     }
 
-    It 'supports -WhatIf without deleting files' {
-        $null = Clear-ObsoleteAdmx -PolicyStore $script:StoreRoot -Languages @('en-US') -WhatIf
+    It 'copies missing language ADMLs from en-US' {
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'fr-FR\windows.adml') | Should -BeFalse
+        $null = Clear-ObsoleteAdmx -PolicyStore $script:StoreRoot -Languages @('en-US', 'fr-FR')
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'fr-FR\windows.adml') | Should -BeTrue
+        (Get-Content -LiteralPath (Join-Path $script:StoreRoot 'fr-FR\windows.adml') -Raw).Trim() | Should -Be 'keep'
+    }
+
+    It 'supports -WhatIf without deleting files or copying ADMLs' {
+        $null = Clear-ObsoleteAdmx -PolicyStore $script:StoreRoot -Languages @('en-US', 'fr-FR') -WhatIf
 
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'WinStoreUI.admx') | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'Microsoft-Windows-Geolocation-WLPAdm.admx') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'readme.txt') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'extract-debris') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:StoreRoot 'windows.admx') | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $script:StoreRoot 'fr-FR\windows.adml') | Should -BeFalse
+    }
+
+}
+
+
+Describe 'ADMX revision stamping' {
+    It 'converts <SourceVersion> to <Expected>' -ForEach @(
+        @{ SourceVersion = '143.0.3624.0'; Expected = '143.0' }
+        @{ SourceVersion = '0.95.1'; Expected = '0.95' }
+        @{ SourceVersion = '1.2'; Expected = '1.2' }
+        @{ SourceVersion = '108542.1.0'; Expected = '108542.1' }
+        @{ SourceVersion = 'v1.17.0'; Expected = '1.17' }
+    ) {
+        ConvertTo-AdmxRevisionString -Version $SourceVersion | Should -Be $Expected
+    }
+
+    It 'returns null for non-parseable versions' {
+        ConvertTo-AdmxRevisionString -Version 'not-a-version' -WarningAction SilentlyContinue | Should -BeNullOrEmpty
+    }
+
+    It 'stamps only revision 1.0 attributes and leaves higher revisions alone' {
+        $root = Join-Path -Path $TestDrive -ChildPath 'admxrev'
+        $lang = Join-Path -Path $root -ChildPath 'en-US'
+        $null = New-Item -Path $lang -ItemType Directory -Force
+
+        $admxOne = '<?xml version="1.0" encoding="utf-8"?><policyDefinitions revision="1.0" schemaVersion="1.0"><policyNamespaces><target prefix="demo" namespace="Demo.Policies" /></policyNamespaces><resources minRequiredRevision="1.0" /></policyDefinitions>'
+        $admxHigh = '<?xml version="1.0" encoding="utf-8"?><policyDefinitions revision="4.8" schemaVersion="1.0"><policyNamespaces><target prefix="parent" namespace="Parent.Policies" /></policyNamespaces><resources minRequiredRevision="4.8" /></policyDefinitions>'
+        $admlOne = '<?xml version="1.0" encoding="utf-8"?><policyDefinitionResources revision="1.0" schemaVersion="1.0"><displayName>Demo</displayName><resources /></policyDefinitionResources>'
+        $admlHigh = '<?xml version="1.0" encoding="utf-8"?><policyDefinitionResources revision="1.20" schemaVersion="1.0"><displayName>Parent</displayName><resources /></policyDefinitionResources>'
+
+        Set-Content -LiteralPath (Join-Path $root 'demo.admx') -Value $admxOne -Encoding utf8
+        Set-Content -LiteralPath (Join-Path $root 'parent.admx') -Value $admxHigh -Encoding utf8
+        Set-Content -LiteralPath (Join-Path $lang 'demo.adml') -Value $admlOne -Encoding utf8
+        Set-Content -LiteralPath (Join-Path $lang 'parent.adml') -Value $admlHigh -Encoding utf8
+
+        Set-AdmxRevision -Path $root -Revision '143.0'
+
+        ([xml](Get-Content -LiteralPath (Join-Path $root 'demo.admx') -Raw)).policyDefinitions.revision | Should -Be '143.0'
+        ([xml](Get-Content -LiteralPath (Join-Path $root 'demo.admx') -Raw)).policyDefinitions.resources.minRequiredRevision | Should -Be '143.0'
+        ([xml](Get-Content -LiteralPath (Join-Path $lang 'demo.adml') -Raw)).policyDefinitionResources.revision | Should -Be '143.0'
+        ([xml](Get-Content -LiteralPath (Join-Path $root 'parent.admx') -Raw)).policyDefinitions.revision | Should -Be '4.8'
+        ([xml](Get-Content -LiteralPath (Join-Path $lang 'parent.adml') -Raw)).policyDefinitionResources.revision | Should -Be '1.20'
     }
 }
+


### PR DESCRIPTION
## Summary
- Add ADMX support for Specops Authentication Client, WSL, Lenovo Dock Manager, PDF-XChange, RealVNC Connect, ABBYY FineReader PDF, Admin By Request, and GoTo
- Add `-StampAdmxRevision` so Intune shows meaningful ADMX/ADML template versions from the product release Version
- Extend `-CleanPolicyStore` / `-CleanPolicyStoreOnly` to remove superseded Geolocation ADMX and copy missing language ADMLs from `en-US`
- Update README/CHANGELOG for 2608.0 and expand related Pester coverage

## Test plan
- [ ] Run unit tests: `Invoke-Pester -Path tests/EvergreenAdmx.Tests.ps1`
- [ ] Spot-check new products with `-Include` (e.g. WSL, Specops Authentication Client, RealVNC Connect)
- [ ] Verify `-StampAdmxRevision` stamps `revision` / `minRequiredRevision` as Major.Minor and leaves files already above `1.0` unchanged
- [ ] Verify `-CleanPolicyStoreOnly` removes `Microsoft-Windows-Geolocation-WLPAdm` and fills missing language ADMLs from `en-US`
- [ ] Confirm CI (ci.yml) passes on the PR
